### PR TITLE
Allow integer arguments.

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -239,8 +239,8 @@ class BaseClient(object):
     # These all need to be rendered down to a string, let's just check that
     # they are up front and fail fast
     for arg in list(args) + [kwargs[x] for x in kwargs]:
-      if not isinstance(arg, basestring):
-        raise exceptions.TaskclusterFailure('Arguments "%s" to %s is not a string' % (arg, entry['name']))
+      if not isinstance(arg, basestring) and not isinstance(arg, int):
+        raise exceptions.TaskclusterFailure('Arguments "%s" to %s is not a string or int' % (arg, entry['name']))
 
     if len(args) > 0 and len(kwargs) > 0:
       raise exceptions.TaskclusterFailure('Specify either positional or key word arguments')
@@ -298,7 +298,7 @@ class BaseClient(object):
       toReplace = "<%s>" % arg
       if toReplace not in route:
         raise exceptions.TaskclusterFailure('Arg %s not found in route for %s' % (arg, entry['name']))
-      route = route.replace("<%s>" % arg, val)
+      route = route.replace("<%s>" % arg, str(val))
 
     return route.lstrip('/')
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -89,6 +89,12 @@ class TestProcessArgs(ClientTest):
     actual = self.client._processArgs(entry, test2='still works', test='works')
     self.assertEqual(expected, actual)
 
+  def test_int_args(self):
+    expected = {'test': 'works', 'test2': 42}
+    entry = {'args': ['test', 'test2'], 'name': 'test'}
+    actual = self.client._processArgs(entry, 'works', 42)
+    self.assertEqual(expected, actual)
+
   def test_keyword_and_positional(self):
     entry = {'args': ['test'], 'name': 'test'}
     with self.assertRaises(exc.TaskclusterFailure):
@@ -121,10 +127,6 @@ class TestProcessArgs(ClientTest):
   def test_invalid_positional_not_string_non_empty_dict(self):
     with self.assertRaises(exc.TaskclusterFailure):
       self.client._processArgs({'args': ['test'], 'name': 'test'}, {'john': 'ford'})
-
-  def test_invalid_positional_not_string_int(self):
-    with self.assertRaises(exc.TaskclusterFailure):
-      self.client._processArgs({'args': ['test'], 'name': 'test'}, 4)
 
 
 class TestMakeSingleHttpRequest(ClientTest):


### PR DESCRIPTION
This helps for things like the runId, which are ints in the task
structure.