### PR TITLE
Bug 1124110 - log HTTP traffic in debug output for communication with API endpoints

### DIFF
--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -125,8 +125,17 @@ def makeHttpRequest(method, url, payload, headers, retries=MAX_RETRIES):
 
 
 def makeSingleHttpRequest(method, url, payload, headers):
-  log.debug('Making a %s request to %s', method, url)
-  return requests.request(method.upper(), url, data=payload, headers=headers)
+  log.debug('Making a %s request to %s', method.upper(), url)
+  log.debug('Sending HTTP request headers:')
+  log.debug(headers)
+  log.debug('Sending HTTP request payload:')
+  log.debug(payload)
+  response = requests.request(method.upper(), url, data=payload, headers=headers)
+  log.debug('Received HTTP response headers:')
+  log.debug(response.headers)
+  log.debug('Received HTTP response body:')
+  log.debug(response.text)
+  return response
 
 
 def putFile(filename, url, contentType):


### PR DESCRIPTION
This change adds logging of http headers and payloads (both request and response) when debugging is enabled (via DEBUG_TASKCLUSTER_CLIENT env var) in taskcluster-client.py library.

This is to aid troubleshooting in the case an API call fails, but it is not understood the reasons why, or what the response was from the API endpoint.