### PR TITLE
Support steaming download.

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -426,7 +426,11 @@ class BaseClient(object):
 
       # Try to load JSON
       try:
-        return response.json()
+        content_type = response.headers.get('content-type')
+        if content_type is not None and 'json' in content_type.lower():
+            return response.json()
+        else:
+            return {"response": response}
       except ValueError:
         return {"response": response}
 

--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -132,11 +132,9 @@ def makeSingleHttpRequest(method, url, payload, headers):
   log.debug('Making a %s request to %s', method, url)
   log.debug('HTTP Headers: %s' % str(headers))
   log.debug('HTTP Payload: %s (limit 100 char)' % str(payload)[:100])
-  response = requests.request(method.upper(), url, data=payload, headers=headers)
+  response = requests.request(method.upper(), url, data=payload, headers=headers, stream=True)
   log.debug('Received HTTP Status:  %s' % response.status_code)
   log.debug('Received HTTP Headers: %s' % str(response.headers))
-  log.debug('Received HTTP Payload: %s (limit 1024 char)' % str(response.text)[:1024])
-
   return response
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -136,6 +136,7 @@ class TestProcessArgs(ClientTest):
 class ObjWithDotJson(object):
   def __init__(self, status_code, x):
     self.status_code = status_code
+    self.headers = {'content-type': 'application/json'}
     self.x = x
 
   def json(self):


### PR DESCRIPTION
- remove response.text in util (fix the UnicodeEncodeError when downloading files)
- run response.json only if the headers['content-type'] is json format