### PR TITLE
Bug 1194767 - use 'nice' slugids from slugid.py package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ tests_require = [
   'subprocess32==3.2.6',
   'psutil==2.1.3',
   'hypothesis',
-  'pgpy',
-  'slugid'
+  'pgpy'
 ]
 
 install_requires = [
   'requests>=2.4.3,<=2.7.0',
   'PyHawk_with_a_single_extra_commit==0.1.5',
   #  'PyHawk==0.1.4',
+  'slugid',
 ]
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ tests_require = [
   'subprocess32==3.2.6',
   'psutil==2.1.3',
   'hypothesis',
-  'pgpy'
+  'pgpy',
+  'slugid'
 ]
 
 install_requires = [

--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -1,11 +1,11 @@
 import re
 import json
 import datetime
-import uuid
 import base64
 import logging
 import os
 import requests
+import slugid as slugid_
 import time
 
 MAX_RETRIES = 5
@@ -89,7 +89,7 @@ def encodeStringForB64Header(s):
 def slugId():
   """ Generate a taskcluster slugid.  This is a V4 UUID encoded into
   URL-Safe Base64 (RFC 4648, sec 5) with '=' padding removed """
-  return makeB64UrlSafe(encodeStringForB64Header(uuid.uuid4().bytes).replace('=', ''))
+  return slugid_.nice()
 
 
 def stableSlugId():

--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -5,7 +5,7 @@ import base64
 import logging
 import os
 import requests
-import slugid as slugid_
+import slugid
 import time
 
 MAX_RETRIES = 5
@@ -89,7 +89,7 @@ def encodeStringForB64Header(s):
 def slugId():
   """ Generate a taskcluster slugid.  This is a V4 UUID encoded into
   URL-Safe Base64 (RFC 4648, sec 5) with '=' padding removed """
-  return slugid_.nice()
+  return slugid.nice()
 
 
 def stableSlugId():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -110,20 +110,18 @@ class TestBase64Utils(base.TCTest):
     self.assertEqual(expected, actual)
 
 
-# first bit of uuid set, which should get unset
-class TestSlugIdNotNice(base.TCTest):
-  def test_slug_id(self):
+class TestSlugId(base.TCTest):
+  def test_slug_id_is_always_nice(self):
     with mock.patch('uuid.uuid4') as p:
+      # first bit of uuid set, which should get unset
       p.return_value = uuid.UUID('bed97923-7616-4ec8-85ed-4b695f67ac2e')
       expected = 'Ptl5I3YWTsiF7UtpX2esLg'
       actual = subject.slugId()
       self.assertEqual(expected, actual)
 
-
-# first bit of uuid unset, should remain unset
-class TestSlugIdNice(base.TCTest):
-  def test_slug_id(self):
+  def test_slug_id_nice_stays_nice(self):
     with mock.patch('uuid.uuid4') as p:
+      # first bit of uuid unset, should remain unset
       p.return_value = uuid.UUID('3ed97923-7616-4ec8-85ed-4b695f67ac2e')
       expected = 'Ptl5I3YWTsiF7UtpX2esLg'
       actual = subject.slugId()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -110,11 +110,22 @@ class TestBase64Utils(base.TCTest):
     self.assertEqual(expected, actual)
 
 
-class TestSlugId(base.TCTest):
+# first bit of uuid set, which should get unset
+class TestSlugIdNotNice(base.TCTest):
   def test_slug_id(self):
     with mock.patch('uuid.uuid4') as p:
       p.return_value = uuid.UUID('bed97923-7616-4ec8-85ed-4b695f67ac2e')
-      expected = 'vtl5I3YWTsiF7UtpX2esLg'
+      expected = 'Ptl5I3YWTsiF7UtpX2esLg'
+      actual = subject.slugId()
+      self.assertEqual(expected, actual)
+
+
+# first bit of uuid unset, should remain unset
+class TestSlugIdNice(base.TCTest):
+  def test_slug_id(self):
+    with mock.patch('uuid.uuid4') as p:
+      p.return_value = uuid.UUID('3ed97923-7616-4ec8-85ed-4b695f67ac2e')
+      expected = 'Ptl5I3YWTsiF7UtpX2esLg'
       actual = subject.slugId()
       self.assertEqual(expected, actual)
 


### PR DESCRIPTION
Regarding the tests, now that the new slugid library has [its own tests](https://github.com/taskcluster/slugid.py/blob/master/test.py), there is an argument we could remove the slug tests from this library. However maybe it is also nice to keep them as an extra safety guarantee. The current tests in this library stub the `uuid.uuid4()` function since previously the slugid generation process in this taskcluster client was using `uuid.uuid4()`. The new [slugid client](https://pypi.python.org/pypi/slugid) is also using `uuid.uuid4()`, but since now this is implemented in an external library, this could change, so if we keep the tests we also now making assumptions about the other library's implementation. This might be another reason to remove the tests.

I don't mind either way, let me know what you think.