### PR TITLE
Fixed bewit

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -437,7 +437,7 @@ class TestBuildSignedUrl(ClientTest):
   def test_builds_surl_positional(self):
     expBewit = 'Y2xpZW50SWRcOTAxXENVUHFtY1lSeW5Ua' + \
                '3NBS1BDaTJLUm5palgwR3hpWjFRUE9rMF' + \
-               'Viamc2U1U9XGUzMD0='
+               'Viamc2U1U9XGUzMD0'
     expected = 'https://localhost:8555/v1/two_args_no_input/arg0/arg1?bewit=' + expBewit
     actual = self.client.buildSignedUrl('two_args_no_input', 'arg0', 'arg1')
     self.assertEqual(expected, actual)
@@ -445,7 +445,7 @@ class TestBuildSignedUrl(ClientTest):
   def test_builds_surl_keyword(self):
     expBewit = 'Y2xpZW50SWRcOTAxXENVUHFtY1lSeW5Ua' + \
                '3NBS1BDaTJLUm5palgwR3hpWjFRUE9rMF' + \
-               'Viamc2U1U9XGUzMD0='
+               'Viamc2U1U9XGUzMD0'
     expected = 'https://localhost:8555/v1/two_args_no_input/arg0/arg1?bewit=' + expBewit
     actual = self.client.buildSignedUrl('two_args_no_input', arg0='arg0', arg1='arg1')
     self.assertEqual(expected, actual)
@@ -564,8 +564,8 @@ class TestAuthenticationMockServer(base.TCTest):
     client = self.clientClass({
       'baseUrl': self.baseUrl,
       'credentials': {
-        'clientId': 'expired',
-        'accessToken': 'expiredToken',
+        'clientId': 'badScope',
+        'accessToken': 'badScopeToken',
       }
     })
     signedUrl = client.buildSignedUrl('getCredentials', 'admin')


### PR DESCRIPTION
Please merge #27 first...
This fixes bewit... so that it always works... at least that what I got from testing it...


If you want to test it try:
```python
import taskcluster, os, requests

queue = taskcluster.Queue({
  'credentials': {
    'clientId': os.environ.get('TASKCLUSTER_CLIENT_ID', '').encode('utf-8'),
    'accessToken': os.environ.get('TASKCLUSTER_ACCESS_TOKEN', '').encode('utf-8'),
    'certificate': os.environ.get('TASKCLUSTER_CERTIFICATE', '').encode('utf-8'),
  },
  'authorizedScopes': ['*'],
  'maxRetries': 1,
})

taskId = taskcluster.utils.slugId();

url = queue.buildSignedUrl('getArtifact', taskId, 0, "private/artifact")
r = requests.get(url)
print ""
print "------------------------------"
print ""
print url
print ""
print "Result:"
print r.status_code
print r.text
```

We probably should test it against the mock auth server... but the code is a bit too confusing for me... So leaving that as an exercise for the reader...

------
This implementation fixes specific issues with PyHawk and relies on specifics in node hawk library... which is the reference implementation for reference see:
 * https://github.com/jhford/PyHawk/blob/5d2dea3d5934ea4214acabc89b643f07995a7dee/hawk/hcrypto.py#L120-L127
 * https://github.com/jhford/PyHawk/blob/5d2dea3d5934ea4214acabc89b643f07995a7dee/hawk/hcrypto.py#L31-L40
 * https://github.com/hueniverse/hawk/blob/fdb9d05e383d5237631eaddc4f51422e54fa8b52/lib/server.js#L356
 * https://github.com/hapijs/hoek/blob/20f36e85616264d4b73a64a374803175213a9121/lib/index.js#L791-L815