### PR TITLE
quote / to %2F in an argument

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -304,7 +304,7 @@ class BaseClient(object):
       toReplace = "<%s>" % arg
       if toReplace not in route:
         raise exceptions.TaskclusterFailure('Arg %s not found in route for %s' % (arg, entry['name']))
-      val = urllib.quote(str(val).encode("utf-8"))
+      val = urllib.quote(str(val).encode("utf-8"), '')
       route = route.replace("<%s>" % arg, val)
 
     return route.lstrip('/')


### PR DESCRIPTION
I recall some discussion of this before, but I don't remember if it applied to the Python client.  Without this hack, I can't fetch roles with `/` in the name.