### PR TITLE
Added authenticate method for using login.taskcluster.net

### DIFF
--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -7,10 +7,6 @@ import os
 import requests
 import slugid
 import time
-import webbrowser
-import urlparse
-import BaseHTTPServer
-import urllib
 import sys
 
 MAX_RETRIES = 5
@@ -264,39 +260,7 @@ def _decrypt(blob, privateKey):
   return decrypted.message
 
 
-class _AuthCallBackRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
-  def __init__(self, setCredentials, *args):
-    self.setCredentials = setCredentials
-    BaseHTTPServer.BaseHTTPRequestHandler.__init__(self, *args)
-
-  def log_message(format, *args):
-    pass
-  def do_GET(self):
-    url = urlparse.urlparse(self.path)
-    query = urlparse.parse_qs(url.query)
-    clientId = query.get('clientId', [None])[0]
-    accessToken = query.get('accessToken', [None])[0]
-    certificate = query.get('certificate', [None])[0]
-    hasCreds = clientId and accessToken and certificate
-    if hasCreds:
-      self.setCredentials(clientId, accessToken, certificate)
-    self.send_response(200)
-    self.send_header('Content-type','text/html')
-    self.end_headers()
-    if hasCreds:
-      self.wfile.write("""
-        <h1>Credentials transferred successfully</h1>
-        <i>You can close this window now.</i>
-        <script>window.close();</script>
-      """)
-    else:
-      self.wfile.write("""
-        <h1>Transfer of credentials failed!</h1>
-        <p>Something went wrong, you can navigate back and try again...</p>
-      """)
-    return
-
-def authenticate(description = None):
+def authenticate(description=None):
   """
     Open a web-browser to login.taskcluster.net and listen on localhost for
     a callback with credentials in query-string.
@@ -304,6 +268,14 @@ def authenticate(description = None):
     The description will be shown on login.taskcluster.net, if not provided
     a default message with script path will be displayed.
   """
+  # Importing here to avoid loading these 'obscure' module before it's needed.
+  # Most clients won't use this feature, so we don't want issues with these
+  # modules to affect the library. Maybe they don't work in some environments
+  import webbrowser
+  import urlparse
+  import BaseHTTPServer
+  import urllib
+
   if not description:
     script = '[interpreter/unknown]'
     main = sys.modules.get('__main__', None)
@@ -315,20 +287,45 @@ def authenticate(description = None):
     )
 
   creds = [None]
-  def setCredentials(clientId, accessToken, certificate):
-    creds[0] = {
-      "clientId": clientId,
-      "accessToken": accessToken,
-      "certificate": certificate
-    };
+
+  class AuthCallBackRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    def log_message(format, *args):
+      pass
+
+    def do_GET(self):
+      url = urlparse.urlparse(self.path)
+      query = urlparse.parse_qs(url.query)
+      clientId = query.get('clientId', [None])[0]
+      accessToken = query.get('accessToken', [None])[0]
+      certificate = query.get('certificate', [None])[0]
+      hasCreds = clientId and accessToken and certificate
+      if hasCreds:
+        creds[0] = {
+          "clientId": clientId,
+          "accessToken": accessToken,
+          "certificate": certificate
+        }
+      self.send_response(200)
+      self.send_header('Content-type', 'text/html')
+      self.end_headers()
+      if hasCreds:
+        self.wfile.write("""
+          <h1>Credentials transferred successfully</h1>
+          <i>You can close this window now.</i>
+          <script>window.close();</script>
+        """)
+      else:
+        self.wfile.write("""
+          <h1>Transfer of credentials failed!</h1>
+          <p>Something went wrong, you can navigate back and try again...</p>
+        """)
+      return
 
   # Create server on localhost at random port
   retries = 5
   while retries > 0:
     try:
-      def requestHandler(*args):
-        _AuthCallBackRequestHandler(setCredentials, *args)
-      server = BaseHTTPServer.HTTPServer(('', 0), requestHandler)
+      server = BaseHTTPServer.HTTPServer(('', 0), AuthCallBackRequestHandler)
     except:
       retries -= 1
     break


### PR DESCRIPTION
This is lovely crazy and awesome... mozregression should probably used this, it would save them a lot of pain (I hope).

It needs docs in `README.md` as I don't really know how the `utils.py` thing is exposed...


Or we should just generate readthedocs things... for this...