### PR TITLE
Make Not using hawk! messages to be debug instead of info

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -388,7 +388,7 @@ class BaseClient(object):
 
                 headers = {'Authorization': sender.request_header}
             else:
-                log.info('Not using hawk!')
+                log.debug('Not using hawk!')
                 headers = {}
             if payload:
                 # Set header for JSON if payload is given, note that we serialize


### PR DESCRIPTION
I'm building a tool which analyzes a very busy pulse queue and I get this message every single time I use the taskcluster python library.