### PR TITLE
Support named temporary credentials

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -636,6 +636,25 @@ class TestAuthentication(base.TCTest):
         })
         self.assertEqual(result, {'scopes': ['test:xyz'], 'clientId': 'tester'})
 
+    def test_named_temporary_credentials(self):
+        tempCred = subject.createTemporaryCredentials(
+            'tester',
+            'no-secret',
+            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            ['test:xyz'],
+            name='credName'
+        )
+        client = subject.Auth({
+            'credentials': tempCred,
+        })
+
+        result = client.testAuthenticate({
+            'clientScopes': ['test:*', 'auth:create-client:credName'],
+            'requiredScopes': ['test:xyz'],
+        })
+        self.assertEqual(result, {'scopes': ['test:xyz'], 'clientId': 'credName'})
+
     def test_temporary_credentials_authorizedScopes(self):
         tempCred = subject.createTemporaryCredentials(
             'tester',
@@ -655,6 +674,27 @@ class TestAuthentication(base.TCTest):
         })
         self.assertEqual(result, {'scopes': ['test:xyz:abc'],
                                   'clientId': 'tester'})
+
+    def test_named_temporary_credentials_authorizedScopes(self):
+        tempCred = subject.createTemporaryCredentials(
+            'tester',
+            'no-secret',
+            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            ['test:xyz:*'],
+            name='credName'
+        )
+        client = subject.Auth({
+            'credentials': tempCred,
+            'authorizedScopes': ['test:xyz:abc'],
+        })
+
+        result = client.testAuthenticate({
+            'clientScopes': ['test:*', 'auth:create-client:credName'],
+            'requiredScopes': ['test:xyz:abc'],
+        })
+        self.assertEqual(result, {'scopes': ['test:xyz:abc'],
+                                  'clientId': 'credName'})
 
     def test_signed_url(self):
         """we can use a signed url built with the python client"""


### PR DESCRIPTION
This adds support for creating named temporary credentials to the `createTemporaryCredentials` function.  I don't particularly like this function signature, but it doesn't leave any other options. I don't see the function documented anywhere, so I didn't update anything except the docstring (which inaccurately described the existing options)