### PR TITLE
README: Remove leftover mention of PyHawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ The REST API methods are documented on
     index.listNamespaces('mozilla-central', payload={'continuationToken': 'a_token'})
     ```
 
-There is a bug in the PyHawk library (as of 0.1.3) which breaks bewit
-generation for URLs that do not have a query string.  This is being addressed
-in [PyHawk PR 27](https://github.com/mozilla/PyHawk/pull/27).
-
 Logging is set up in `taskcluster/__init__.py`.  If the special `DEBUG_TASKCLUSTER_CLIENT`
 environment variable is set, the `__init__.py` module will set the `logging` module's level
 for its logger to `logging.DEBUG` and if there are no existing handlers, add a


### PR DESCRIPTION
Since it was replaced by mohawk.

Fixes #54.