### PR TITLE
Suport hawk header directly in credentials.

### DIFF
--- a/taskcluster/baseclient.py
+++ b/taskcluster/baseclient.py
@@ -30,7 +30,7 @@ _defaultConfig = config = {
         'clientId': os.environ.get('TASKCLUSTER_CLIENT_ID'),
         'accessToken': os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
         'certificate': os.environ.get('TASKCLUSTER_CERTIFICATE'),
-        'hawkHeader' : None,
+        'hawkHeader': None,
     },
     'maxRetries': 5,
     'signedUrlExpiration': 15 * 60,

--- a/taskcluster/baseclient.py
+++ b/taskcluster/baseclient.py
@@ -30,6 +30,7 @@ _defaultConfig = config = {
         'clientId': os.environ.get('TASKCLUSTER_CLIENT_ID'),
         'accessToken': os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
         'certificate': os.environ.get('TASKCLUSTER_CERTIFICATE'),
+        'hawkHeader' : None,
     },
     'maxRetries': 5,
     'signedUrlExpiration': 15 * 60,
@@ -52,7 +53,7 @@ class BaseClient(object):
 
         credentials = o.get('credentials')
         if credentials:
-            for x in ('accessToken', 'clientId', 'certificate'):
+            for x in ('accessToken', 'clientId', 'certificate', 'hawkHeader'):
                 value = credentials.get(x)
                 if value and not isinstance(value, six.binary_type):
                     try:
@@ -256,6 +257,15 @@ class BaseClient(object):
             cred['accessToken']
         )
 
+    def _hasHawkHeader(self):
+        """ Return True, if hawk header is already given """
+        cred = self.options.get('credentials')
+        return (
+            cred and
+            'hawkHeader' in cred and
+            cred['hawkHeader']
+        )
+
     def makeQueryString(self, options, validOptions=None):
         if not options:
             return ''
@@ -296,6 +306,8 @@ class BaseClient(object):
             )
 
             headers = {'Authorization': sender.request_header}
+        elif self._hasHawkHeader():
+            headers = {'Authorization': self.options['credentials']['hawkHeader']}
         else:
             log.debug('Not using hawk!')
             headers = {}

--- a/taskcluster/baseclient.py
+++ b/taskcluster/baseclient.py
@@ -260,11 +260,7 @@ class BaseClient(object):
     def _hasHawkHeader(self):
         """ Return True, if hawk header is already given """
         cred = self.options.get('credentials')
-        return (
-            cred and
-            'hawkHeader' in cred and
-            cred['hawkHeader']
-        )
+        return cred and cred.get('hawkHeader', False)
 
     def makeQueryString(self, options, validOptions=None):
         if not options:

--- a/test/test_baseclient.py
+++ b/test/test_baseclient.py
@@ -57,8 +57,8 @@ class TestBaseClient(unittest.TestCase):
         """test_base_client | test makeHeaders
         """
         options = {
-            'credentials' : {
-                'hawkHeader' : 'Hawk no-secret ext="empty" mac="fake"',
+            'credentials': {
+                'hawkHeader': 'Hawk no-secret ext="empty" mac="fake"',
             }
         }
         client = BC(options)

--- a/test/test_baseclient.py
+++ b/test/test_baseclient.py
@@ -52,3 +52,18 @@ class TestBaseClient(unittest.TestCase):
         route = "/asdf/foo/bar"
         url = client.makeFullUrl(route, validOptions=['a', 'b'], options={'a': 1})
         self.assertEqual(url, FAKE_URL + route + "?a=1")
+
+    def test_makeHeaders_hawk(self):
+        """test_base_client | test makeHeaders
+        """
+        options = {
+            'credentials' : {
+                'hawkHeader' : 'Hawk no-secret ext="empty" mac="fake"',
+            }
+        }
+        client = BC(options)
+        route = "/asdf/foo/bar"
+        url = client.makeFullUrl(route)
+        headers = client.makeHeaders('GET', url, {}, None)
+        self.assertIn('Authorization', headers)
+        self.assertEqual(headers['Authorization'], options['credentials']['hawkHeader'])


### PR DESCRIPTION
Hello TC maintainers,

I'm working on a [Mozilla project](https://github.com/mozilla-releng/services/) using TaskCluster auth from a web app in 2 parts:
- a javascript frontend gets and stores the TC credentials. It can then build some hawk authentication header
- a python backend uses TC authenticateHawk to authorize the requests from the frontend

The project needs to use more services from TaskCluster (secrets, queues, ...) and in order to avoid transmitting the full TC credentials to the backend, we'd like to send directly the hawk header for a request to the TC python client.

So this Pull request adds an extra credential option, permitting to use an existing hawk header.

Thanks for your review.
