### PR TITLE
Generate wheels in addition to the source distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 		done \
 	fi
 	rm -rf filescreated.dat .tox htmlcov .coverage nosetests.xml README.html
-	rm -rf *.egg *.egg-info .eggs/ dist/
+	rm -rf *.egg *.egg-info .eggs/ dist/ build/
 	find . -name "*.py?" -exec rm {} +
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type d -name .hypothesis -exec rm -rf {} +

--- a/release.sh
+++ b/release.sh
@@ -106,4 +106,17 @@ fi
 git commit -m "Version $VERSION"
 git tag "$VERSION"
 git push "${OFFICIAL_GIT_REPO}" "+refs/tags/$VERSION:refs/tags/$VERSION" "+refs/tags/$VERSION:refs/heads/master"
-./.tox/py35/bin/python setup.py sdist upload
+
+# Generate a source distribution as well as Python 2 and 3
+# variants of wheels (since the contents differs for each).
+# Tox already installed recent setuptools and wheel for us.
+./.tox/py35/bin/python setup.py sdist
+./.tox/py35/bin/python setup.py bdist_wheel
+# Work around https://bitbucket.org/pypa/wheel/issues/147/bdist_wheel-should-start-by-cleaning-up
+rm -rf build/
+./.tox/py27/bin/python setup.py bdist_wheel
+
+# Publish to PyPI using Twine, as recommended by:
+# https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi
+./.tox/py35/bin/pip install -U twine
+./.tox/py35/bin/twine upload dist/*


### PR DESCRIPTION
The release script now generates wheels - one for each of Python 2 and Python 3 (since the contents for each will soon differ once the `async` directory is excluded on Python 2). In addition, the upload is now performed using Twine, as recommended by the official PyPA packaging guide.

Note: If you inspect the wheel for each of Python 2 and 3, you can see the METADATA file in the *.dist-info directory correctly includes the aiohttp and friends dependencies on Python 3, and omits them on Python 2.

A later PR will exclude the `async` directory from the wheel entirely on Python 2.

Fixes #79.