### PR TITLE
Enable Query-String options implementation

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -163,7 +163,7 @@ class BaseClient(object):
         if not entry:
             raise exceptions.TaskclusterFailure(
                 'Requested method "%s" not found in API Reference' % methodName)
-        apiArgs = self._processArgs(entry, *args, **kwargs)
+        apiArgs, options = self._processArgs(entry, *args, **kwargs)
         route = self._subArgsInRoute(entry, apiArgs)
         return self.options['baseUrl'] + '/' + route
 
@@ -241,7 +241,7 @@ class BaseClient(object):
                 payload = _args.pop()
             else:
                 raise exceptions.TaskclusterFailure('Payload is required as last positional arg')
-        apiArgs = self._processArgs(entry, *_args, **_kwargs)
+        apiArgs, options = self._processArgs(entry, *_args, **_kwargs)
         route = self._subArgsInRoute(entry, apiArgs)
         log.debug('Route is: %s', route)
 
@@ -257,6 +257,7 @@ class BaseClient(object):
 
         reqArgs = entry['args']
         data = {}
+        options = None
 
         # These all need to be rendered down to a string, let's just check that
         # they are up front and fail fast
@@ -311,7 +312,7 @@ class BaseClient(object):
                 log.error(errMsg)
                 raise exceptions.TaskclusterFailure(errMsg)
 
-        return data
+        return data, options
 
     def _subArgsInRoute(self, entry, args, query=None):
         """ Given a route like "/task/<taskId>/artifacts" and a mapping like

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -313,9 +313,11 @@ class BaseClient(object):
 
         return data
 
-    def _subArgsInRoute(self, entry, args):
+    def _subArgsInRoute(self, entry, args, query=None):
         """ Given a route like "/task/<taskId>/artifacts" and a mapping like
-        {"taskId": "12345"}, return a string like "/task/12345/artifacts"
+        {"taskId": "12345"}, return a string like "/task/12345/artifacts".  If
+        specified, the dictionary passed as the `query` parameter will be
+        encoded into a query string and appended to the route used
         """
 
         route = entry['route']
@@ -327,6 +329,9 @@ class BaseClient(object):
                     'Arg %s not found in route for %s' % (arg, entry['name']))
             val = urllib.parse.quote(str(val).encode("utf-8"), '')
             route = route.replace("<%s>" % arg, val)
+
+        if query:
+          route += '?' + urllib.parse.urlencode(query)
 
         return route.lstrip('/')
 

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -314,10 +314,10 @@ class BaseClient(object):
 
         return data, options
 
-    def _subArgsInRoute(self, entry, args, query=None):
+    def _subArgsInRoute(self, entry, args, options=None):
         """ Given a route like "/task/<taskId>/artifacts" and a mapping like
         {"taskId": "12345"}, return a string like "/task/12345/artifacts".  If
-        specified, the dictionary passed as the `query` parameter will be
+        specified, the dictionary passed as the `options` parameter will be
         encoded into a query string and appended to the route used
         """
 
@@ -331,8 +331,8 @@ class BaseClient(object):
             val = urllib.parse.quote(str(val).encode("utf-8"), '')
             route = route.replace("<%s>" % arg, val)
 
-        if query:
-          route += '?' + urllib.parse.urlencode(query)
+        if options:
+          route += '?' + urllib.parse.urlencode(options)
 
         return route.lstrip('/')
 

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -164,7 +164,7 @@ class BaseClient(object):
             raise exceptions.TaskclusterFailure(
                 'Requested method "%s" not found in API Reference' % methodName)
         apiArgs, options = self._processArgs(entry, *args, **kwargs)
-        route = self._subArgsInRoute(entry, apiArgs)
+        route = self._subArgsInRoute(entry, apiArgs, options)
         return self.options['baseUrl'] + '/' + route
 
     def buildSignedUrl(self, methodName, *args, **kwargs):
@@ -242,7 +242,7 @@ class BaseClient(object):
             else:
                 raise exceptions.TaskclusterFailure('Payload is required as last positional arg')
         apiArgs, options = self._processArgs(entry, *_args, **_kwargs)
-        route = self._subArgsInRoute(entry, apiArgs)
+        route = self._subArgsInRoute(entry, apiArgs, options)
         log.debug('Route is: %s', route)
 
         return self._makeHttpRequest(entry['method'], route, payload)

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -254,6 +254,10 @@ class BaseClient(object):
         options = None
         payload = None
 
+        hasOptions = False
+        if 'query' in entry and len(entry['query']) > 0:
+          hasOptions = True
+
         if 'input' in entry:
           if len(args) > 0:
             payload = args.pop()


### PR DESCRIPTION
This pull request moves a couple things around so that implementing query-string options is a little easier.  This doesn't pass tests, rather it's a WIP.  It also needs to have python3 base classes adapted to also move the payload handling out of `_makeApiCall` and into `_processArgs`