### PR TITLE
Query String Support

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -2177,7 +2177,7 @@
             "runId",
             "name"
           ],
-          "description": "This API end-point creates an artifact for a specific run of a task. This\nshould **only** be used by a worker currently operating on this task, or\nfrom a process running within the task (ie. on the worker).\n\nAll artifacts must specify when they `expires`, the queue will\nautomatically take care of deleting artifacts past their\nexpiration point. This features makes it feasible to upload large\nintermediate artifacts from data processing applications, as the\nartifacts can be set to expire a few days later.\n\nWe currently support 4 different `storageType`s, each storage type have\nslightly different features and in some cases difference semantics.\n\n**S3 artifacts**, is useful for static files which will be stored on S3.\nWhen creating an S3 artifact the queue will return a pre-signed URL\nto which you can do a `PUT` request to upload your artifact. Note\nthat `PUT` request **must** specify the `content-length` header and\n**must** give the `content-type` header the same value as in the request\nto `createArtifact`.\n\n**Azure artifacts**, are stored in _Azure Blob Storage_ service, which\ngiven the consistency guarantees and API interface offered by Azure is\nmore suitable for artifacts that will be modified during the execution\nof the task. For example docker-worker has a feature that persists the\ntask log to Azure Blob Storage every few seconds creating a somewhat\nlive log. A request to create an Azure artifact will return a URL\nfeaturing a [Shared-Access-Signature](http://msdn.microsoft.com/en-us/library/azure/dn140256.aspx),\nrefer to MSDN for further information on how to use these.\n**Warning: azure artifact is currently an experimental feature subject\nto changes and data-drops.**\n\n**Reference artifacts**, only consists of meta-data which the queue will\nstore for you. These artifacts really only have a `url` property and\nwhen the artifact is requested the client will be redirect the URL\nprovided with a `303` (See Other) redirect. Please note that we cannot\ndelete artifacts you upload to other service, we can only delete the\nreference to the artifact, when it expires.\n\n**Error artifacts**, only consists of meta-data which the queue will\nstore for you. These artifacts are only meant to indicate that you the\nworker or the task failed to generate a specific artifact, that you\nwould otherwise have uploaded. For example docker-worker will upload an\nerror artifact, if the file it was supposed to upload doesn't exists or\nturns out to be a directory. Clients requesting an error artifact will\nget a `403` (Forbidden) response. This is mainly designed to ensure that\ndependent tasks can distinguish between artifacts that were suppose to\nbe generated and artifacts for which the name is misspelled.\n\n**Artifact immutability**, generally speaking you cannot overwrite an\nartifact when created. But if you repeat the request with the same\nproperties the request will succeed as the operation is idempotent.\nThis is useful if you need to refresh a signed URL while uploading.\nDo not abuse this to overwrite artifacts created by another entity!\nSuch as worker-host overwriting artifact created by worker-code.\n\nAs a special case the `url` property on _reference artifacts_ can be\nupdated. You should only use this to update the `url` property for\nreference artifacts your process has created.",
+          "description": "This API end-point creates an artifact for a specific run of a task. This\nshould **only** be used by a worker currently operating on this task, or\nfrom a process running within the task (ie. on the worker).\n\nAll artifacts must specify when they `expires`, the queue will\nautomatically take care of deleting artifacts past their\nexpiration point. This features makes it feasible to upload large\nintermediate artifacts from data processing applications, as the\nartifacts can be set to expire a few days later.\n\nWe currently support 3 different `storageType`s, each storage type have\nslightly different features and in some cases difference semantics.\nWe also have 2 deprecated `storageType`s which are only maintained for\nbackwards compatiability and should not be used in new implementations\n\n**Blob artifacts**, are useful for storing large files.  Currently, these\nare all stored in S3 but there are facilities for adding support for other\nbackends in futre.  A call for this type of artifact must provide information\nabout the file which will be uploaded.  This includes sha256 sums and sizes.\nThis method will return a list of general form HTTP requests which are signed\nby AWS S3 credentials managed by the Queue.  Once these requests are completed\nthe list of `ETag` values returned by the requests must be passed to the\nqueue `completeArtifact` method\n\n**S3 artifacts**, DEPRECATED is useful for static files which will be\nstored on S3. When creating an S3 artifact the queue will return a\npre-signed URL to which you can do a `PUT` request to upload your\nartifact. Note that `PUT` request **must** specify the `content-length`\nheader and **must** give the `content-type` header the same value as in\nthe request to `createArtifact`.\n\n**Azure artifacts**, DEPRECATED are stored in _Azure Blob Storage_ service\nwhich given the consistency guarantees and API interface offered by Azure\nis more suitable for artifacts that will be modified during the execution\nof the task. For example docker-worker has a feature that persists the\ntask log to Azure Blob Storage every few seconds creating a somewhat\nlive log. A request to create an Azure artifact will return a URL\nfeaturing a [Shared-Access-Signature](http://msdn.microsoft.com/en-us/library/azure/dn140256.aspx),\nrefer to MSDN for further information on how to use these.\n**Warning: azure artifact is currently an experimental feature subject\nto changes and data-drops.**\n\n**Reference artifacts**, only consists of meta-data which the queue will\nstore for you. These artifacts really only have a `url` property and\nwhen the artifact is requested the client will be redirect the URL\nprovided with a `303` (See Other) redirect. Please note that we cannot\ndelete artifacts you upload to other service, we can only delete the\nreference to the artifact, when it expires.\n\n**Error artifacts**, only consists of meta-data which the queue will\nstore for you. These artifacts are only meant to indicate that you the\nworker or the task failed to generate a specific artifact, that you\nwould otherwise have uploaded. For example docker-worker will upload an\nerror artifact, if the file it was supposed to upload doesn't exists or\nturns out to be a directory. Clients requesting an error artifact will\nget a `403` (Forbidden) response. This is mainly designed to ensure that\ndependent tasks can distinguish between artifacts that were suppose to\nbe generated and artifacts for which the name is misspelled.\n\n**Artifact immutability**, generally speaking you cannot overwrite an\nartifact when created. But if you repeat the request with the same\nproperties the request will succeed as the operation is idempotent.\nThis is useful if you need to refresh a signed URL while uploading.\nDo not abuse this to overwrite artifacts created by another entity!\nSuch as worker-host overwriting artifact created by worker-code.\n\nAs a special case the `url` property on _reference artifacts_ can be\nupdated. You should only use this to update the `url` property for\nreference artifacts your process has created.",
           "input": "http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#",
           "method": "post",
           "name": "createArtifact",
@@ -2195,6 +2195,31 @@
           ],
           "stability": "stable",
           "title": "Create Artifact",
+          "type": "function"
+        },
+        {
+          "args": [
+            "taskId",
+            "runId",
+            "name"
+          ],
+          "description": "This endpoint finalises an upload done through the blob `storageType`.\nThe queue will ensure that the task/run is still allowing artifacts\nto be uploaded.  For single-part S3 blob artifacts, this endpoint\nwill simply ensure the artifact is present in S3.  For multipart S3\nartifacts, the endpoint will perform the commit step of the multipart\nupload flow.  As the final step for both multi and single part artifacts,\nthe `present` entity field will be set to `true` to reflect that the\nartifact is now present and a message published to pulse.  NOTE: This\nendpoint *must* be called for all artifacts of storageType 'blob'",
+          "input": "http://schemas.taskcluster.net/queue/v1/put-artifact-request.json#",
+          "method": "put",
+          "name": "completeArtifact",
+          "query": [],
+          "route": "/task/<taskId>/runs/<runId>/artifacts/<name>",
+          "scopes": [
+            [
+              "queue:create-artifact:<name>",
+              "assume:worker-id:<workerGroup>/<workerId>"
+            ],
+            [
+              "queue:create-artifact:<taskId>/<runId>"
+            ]
+          ],
+          "stability": "experimental",
+          "title": "Complete Artifact",
           "type": "function"
         },
         {
@@ -2288,6 +2313,40 @@
         },
         {
           "args": [
+            "provisionerId"
+          ],
+          "description": "Get an active provisioner.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
+          "method": "get",
+          "name": "getProvisioner",
+          "output": "http://schemas.taskcluster.net/queue/v1/provisioner-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>",
+          "stability": "experimental",
+          "title": "Get an active provisioner",
+          "type": "function"
+        },
+        {
+          "args": [
+            "provisionerId"
+          ],
+          "description": "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:aws-provisioner-v1#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
+          "input": "http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#",
+          "method": "put",
+          "name": "declareProvisioner",
+          "output": "http://schemas.taskcluster.net/queue/v1/provisioner-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>",
+          "scopes": [
+            [
+              "queue:declare-provisioner:<provisionerId>#<property>"
+            ]
+          ],
+          "stability": "experimental",
+          "title": "Update a provisioner",
+          "type": "function"
+        },
+        {
+          "args": [
             "provisionerId",
             "workerType"
           ],
@@ -2323,17 +2382,94 @@
             "provisionerId",
             "workerType"
           ],
-          "description": "Get a list of all active workerGroup/workerId of a workerType.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 workers in a single\npage. You may limit this with the query-string parameter `limit`.",
+          "description": "Get a worker-type from a provisioner.",
+          "method": "get",
+          "name": "getWorkerType",
+          "output": "http://schemas.taskcluster.net/queue/v1/workertype-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>/worker-types/<workerType>",
+          "stability": "experimental",
+          "title": "Get a worker-type",
+          "type": "function"
+        },
+        {
+          "args": [
+            "provisionerId",
+            "workerType"
+          ],
+          "description": "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.",
+          "input": "http://schemas.taskcluster.net/queue/v1/update-workertype-request.json#",
+          "method": "put",
+          "name": "declareWorkerType",
+          "output": "http://schemas.taskcluster.net/queue/v1/workertype-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>/worker-types/<workerType>",
+          "scopes": [
+            [
+              "queue:declare-worker-type:<provisionerId>/<workerType>#<property>"
+            ]
+          ],
+          "stability": "experimental",
+          "title": "Update a worker-type",
+          "type": "function"
+        },
+        {
+          "args": [
+            "provisionerId",
+            "workerType"
+          ],
+          "description": "Get a list of all active workers of a workerType.\n\n`listWorkers` allows a response to be filtered by the `disabled` property.\nTo filter the query, you should call the end-point with `disabled` as a query-string option.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 workers in a single\npage. You may limit this with the query-string parameter `limit`.",
           "method": "get",
           "name": "listWorkers",
           "output": "http://schemas.taskcluster.net/queue/v1/list-workers-response.json#",
           "query": [
             "continuationToken",
-            "limit"
+            "limit",
+            "disabled"
           ],
           "route": "/provisioners/<provisionerId>/worker-types/<workerType>/workers",
           "stability": "experimental",
-          "title": "Get a list of all active workerGroup/workerId of a workerType",
+          "title": "Get a list of all active workers of a workerType",
+          "type": "function"
+        },
+        {
+          "args": [
+            "provisionerId",
+            "workerType",
+            "workerGroup",
+            "workerId"
+          ],
+          "description": "Get a worker from a worker-type.",
+          "method": "get",
+          "name": "getWorker",
+          "output": "http://schemas.taskcluster.net/queue/v1/worker-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>/worker-types/<workerType>/workers/<workerGroup>/<workerId>",
+          "stability": "experimental",
+          "title": "Get a worker-type",
+          "type": "function"
+        },
+        {
+          "args": [
+            "provisionerId",
+            "workerType",
+            "workerGroup",
+            "workerId"
+          ],
+          "description": "Declare a worker, supplying some details about it.\n\n`declareWorker` allows updating one or more properties of a worker as long as the required scopes are\npossessed.",
+          "input": "http://schemas.taskcluster.net/queue/v1/update-worker-request.json#",
+          "method": "put",
+          "name": "declareWorker",
+          "output": "http://schemas.taskcluster.net/queue/v1/worker-response.json#",
+          "query": [],
+          "route": "/provisioners/<provisionerId>/worker-types/<workerType>/<workerGroup>/<workerId>",
+          "scopes": [
+            [
+              "queue:declare-worker:<provisionerId>/<workerType>/<workerGroup><workerId>#<property>"
+            ]
+          ],
+          "stability": "experimental",
+          "title": "Declare a worker",
           "type": "function"
         },
         {
@@ -2897,415 +3033,6 @@
     },
     "referenceUrl": "http://references.taskcluster.net/queue/v1/exchanges.json"
   },
-  "Scheduler": {
-    "reference": {
-      "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
-      "baseUrl": "https://scheduler.taskcluster.net/v1",
-      "description": "The task-graph scheduler, typically available at\n`scheduler.taskcluster.net`, is responsible for accepting task-graphs and\nscheduling tasks for evaluation by the queue as their dependencies are\nsatisfied.\n\nThis document describes API end-points offered by the task-graph\nscheduler. These end-points targets the following audience:\n * Post-commit hooks, that wants to submit task-graphs for testing,\n * End-users, who wants to execute a set of dependent tasks, and\n * Tools, that wants to inspect the state of a task-graph.",
-      "entries": [
-        {
-          "args": [
-            "taskGraphId"
-          ],
-          "description": "Create a new task-graph, the `status` of the resulting JSON is a\ntask-graph status structure, you can find the `taskGraphId` in this\nstructure.\n\n**Referencing required tasks**, it is possible to reference other tasks\nin the task-graph that must be completed successfully before a task is\nscheduled. You just specify the `taskId` in the list of `required` tasks.\nSee the example below, where the second task requires the first task.\n```js\n{\n  ...\n  tasks: [\n    {\n      taskId:     \"XgvL0qtSR92cIWpcwdGKCA\",\n      requires:   [],\n      ...\n    },\n    {\n      taskId:     \"73GsfK62QNKAk2Hg1EEZTQ\",\n      requires:   [\"XgvL0qtSR92cIWpcwdGKCA\"],\n      task: {\n        payload: {\n          env: {\n            DEPENDS_ON:  \"XgvL0qtSR92cIWpcwdGKCA\"\n          }\n          ...\n        }\n        ...\n      },\n      ...\n    }\n  ]\n}\n```\n\n**The `schedulerId` property**, defaults to the `schedulerId` of this\nscheduler in production that is `\"task-graph-scheduler\"`. This\nproperty must be either undefined or set to `\"task-graph-scheduler\"`,\notherwise the task-graph will be rejected.\n\n**The `taskGroupId` property**, defaults to the `taskGraphId` of the\ntask-graph submitted, and if provided much be the `taskGraphId` of\nthe task-graph. Otherwise the task-graph will be rejected.\n\n**Task-graph scopes**, a task-graph is assigned a set of scopes, just\nlike tasks. Tasks within a task-graph cannot have scopes beyond those\nthe task-graph has. The task-graph scheduler will execute all requests\non behalf of a task-graph using the set of scopes assigned to the\ntask-graph. Thus, if you are submitting tasks to `my-worker-type` under\n`my-provisioner` it's important that your task-graph has the scope\nrequired to define tasks for this `provisionerId` and `workerType`.\n(`queue:define-task:..` or `queue:create-task:..`; see the queue for\ndetails on scopes required). Note, the task-graph does not require\npermissions to schedule the tasks (`queue:schedule-task:..`), as this is\ndone with scopes provided by the task-graph scheduler.\n\n**Task-graph specific routing-keys**, using the `taskGraph.routes`\nproperty you may define task-graph specific routing-keys. If a task-graph\nhas a task-graph specific routing-key: `<route>`, then the poster will\nbe required to posses the scope `scheduler:route:<route>`. And when the\nan AMQP message about the task-graph is published the message will be\nCC'ed with the routing-key: `route.<route>`. This is useful if you want\nanother component to listen for completed tasks you have posted.",
-          "input": "http://schemas.taskcluster.net/scheduler/v1/task-graph.json#",
-          "method": "put",
-          "name": "createTaskGraph",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#",
-          "route": "/task-graph/<taskGraphId>",
-          "scopes": [
-            [
-              "scheduler:create-task-graph"
-            ]
-          ],
-          "stability": "experimental",
-          "title": "Create new task-graph",
-          "type": "function"
-        },
-        {
-          "args": [
-            "taskGraphId"
-          ],
-          "description": "Add a set of tasks to an existing task-graph. The request format is very\nsimilar to the request format for creating task-graphs. But `routes`\nkey, `scopes`, `metadata` and `tags` cannot be modified.\n\n**Referencing required tasks**, just as when task-graphs are created,\neach task has a list of required tasks. It is possible to reference\nall `taskId`s within the task-graph.\n\n**Safety,** it is only _safe_ to call this API end-point while the\ntask-graph being modified is still running. If the task-graph is\n_finished_ or _blocked_, this method will leave the task-graph in this\nstate. Hence, it is only truly _safe_ to call this API end-point from\nwithin a task in the task-graph being modified.",
-          "input": "http://schemas.taskcluster.net/scheduler/v1/extend-task-graph-request.json#",
-          "method": "post",
-          "name": "extendTaskGraph",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#",
-          "route": "/task-graph/<taskGraphId>/extend",
-          "scopes": [
-            [
-              "scheduler:extend-task-graph:<taskGraphId>"
-            ]
-          ],
-          "stability": "experimental",
-          "title": "Extend existing task-graph",
-          "type": "function"
-        },
-        {
-          "args": [
-            "taskGraphId"
-          ],
-          "description": "Get task-graph status, this will return the _task-graph status\nstructure_. which can be used to check if a task-graph is `running`,\n`blocked` or `finished`.\n\n**Note**, that `finished` implies successfully completion.",
-          "method": "get",
-          "name": "status",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json",
-          "route": "/task-graph/<taskGraphId>/status",
-          "stability": "experimental",
-          "title": "Task Graph Status",
-          "type": "function"
-        },
-        {
-          "args": [
-            "taskGraphId"
-          ],
-          "description": "Get task-graph information, this includes the _task-graph status\nstructure_, along with `metadata` and `tags`, but not information\nabout all tasks.\n\nIf you want more detailed information use the `inspectTaskGraph`\nend-point instead.",
-          "method": "get",
-          "name": "info",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json",
-          "route": "/task-graph/<taskGraphId>/info",
-          "stability": "experimental",
-          "title": "Task Graph Information",
-          "type": "function"
-        },
-        {
-          "args": [
-            "taskGraphId"
-          ],
-          "description": "Inspect a task-graph, this returns all the information the task-graph\nscheduler knows about the task-graph and the state of its tasks.\n\n**Warning**, some of these fields are borderline internal to the\ntask-graph scheduler and we may choose to change or make them internal\nlater. Also note that note all of the information is formalized yet.\nThe JSON schema will be updated to reflect formalized values, we think\nit's safe to consider the values stable.\n\nTake these considerations into account when using the API end-point,\nas we do not promise it will remain fully backward compatible in\nthe future.",
-          "method": "get",
-          "name": "inspect",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json",
-          "route": "/task-graph/<taskGraphId>/inspect",
-          "stability": "experimental",
-          "title": "Inspect Task Graph",
-          "type": "function"
-        },
-        {
-          "args": [
-            "taskGraphId",
-            "taskId"
-          ],
-          "description": "Inspect a task from a task-graph, this returns all the information the\ntask-graph scheduler knows about the specific task.\n\n**Warning**, some of these fields are borderline internal to the\ntask-graph scheduler and we may choose to change or make them internal\nlater. Also note that note all of the information is formalized yet.\nThe JSON schema will be updated to reflect formalized values, we think\nit's safe to consider the values stable.\n\nTake these considerations into account when using the API end-point,\nas we do not promise it will remain fully backward compatible in\nthe future.",
-          "method": "get",
-          "name": "inspectTask",
-          "output": "http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json",
-          "route": "/task-graph/<taskGraphId>/inspect/<taskId>",
-          "stability": "experimental",
-          "title": "Inspect Task from a Task-Graph",
-          "type": "function"
-        },
-        {
-          "args": [],
-          "description": "Documented later...\n\n**Warning** this api end-point is **not stable**.",
-          "method": "get",
-          "name": "ping",
-          "route": "/ping",
-          "stability": "experimental",
-          "title": "Ping Server",
-          "type": "function"
-        }
-      ],
-      "title": "Task-Graph Scheduler API Documentation",
-      "version": 0
-    },
-    "referenceUrl": "http://references.taskcluster.net/scheduler/v1/api.json"
-  },
-  "SchedulerEvents": {
-    "reference": {
-      "$schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json#",
-      "description": "The scheduler, typically available at `scheduler.taskcluster.net` is\nresponsible for accepting task-graphs and schedule tasks on the queue as\ntheir dependencies are completed successfully.\n\nThis document describes the AMQP exchanges offered by the scheduler,\nwhich allows third-party listeners to monitor task-graph submission and\nresolution. These exchanges targets the following audience:\n * Reporters, who displays the state of task-graphs or emails people on\n   failures, and\n * End-users, who wants notification of completed task-graphs\n\n**Remark**, the task-graph scheduler will require that the `schedulerId`\nfor tasks is set to the `schedulerId` for the task-graph scheduler. In\nproduction the `schedulerId` is typically `\"task-graph-scheduler\"`.\nFurthermore, the task-graph scheduler will also require that\n`taskGroupId` is equal to the `taskGraphId`.\n\nCombined these requirements ensures that `schedulerId` and `taskGroupId`\nhave the same position in the routing keys for the queue exchanges.\nSee queue documentation for details on queue exchanges. Hence, making\nit easy to listen for all tasks in a given task-graph.\n\nNote that routing key entries 2 through 7 used for exchanges on the\ntask-graph scheduler is hardcoded to `_`. This is done to preserve\npositional equivalence with exchanges offered by the queue.",
-      "entries": [
-        {
-          "description": "When a task-graph is submitted it immediately starts running and a\nmessage is posted on this exchange to indicate that a task-graph have\nbeen submitted.",
-          "exchange": "task-graph-running",
-          "name": "taskGraphRunning",
-          "routingKey": [
-            {
-              "constant": "primary",
-              "multipleWords": false,
-              "name": "routingKeyKind",
-              "required": true,
-              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "runId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerGroup",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "provisionerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerType",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "schedulerId",
-              "required": true,
-              "summary": "Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskGraphId",
-              "required": true,
-              "summary": "Identifier for the task-graph this message concerns"
-            },
-            {
-              "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
-            }
-          ],
-          "schema": "http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#",
-          "title": "Task-Graph Running Message",
-          "type": "topic-exchange"
-        },
-        {
-          "description": "When a task-graph is extended, that is additional tasks is added to the\ntask-graph, a message is posted on this exchange. This is useful if you\nare monitoring a task-graph and what to track states of the individual\ntasks in the task-graph.",
-          "exchange": "task-graph-extended",
-          "name": "taskGraphExtended",
-          "routingKey": [
-            {
-              "constant": "primary",
-              "multipleWords": false,
-              "name": "routingKeyKind",
-              "required": true,
-              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "runId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerGroup",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "provisionerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerType",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "schedulerId",
-              "required": true,
-              "summary": "Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskGraphId",
-              "required": true,
-              "summary": "Identifier for the task-graph this message concerns"
-            },
-            {
-              "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
-            }
-          ],
-          "schema": "http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#",
-          "title": "Task-Graph Extended Message",
-          "type": "topic-exchange"
-        },
-        {
-          "description": "When a task is completed unsuccessfully and all reruns have been\nattempted, the task-graph will not complete successfully and it's\ndeclared to be _blocked_, by some task that consistently completes\nunsuccessfully.\n\nWhen a task-graph becomes blocked a messages is posted to this exchange.\nThe message features the `taskId` of the task that caused the task-graph\nto become blocked.",
-          "exchange": "task-graph-blocked",
-          "name": "taskGraphBlocked",
-          "routingKey": [
-            {
-              "constant": "primary",
-              "multipleWords": false,
-              "name": "routingKeyKind",
-              "required": true,
-              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "runId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerGroup",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "provisionerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerType",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "schedulerId",
-              "required": true,
-              "summary": "Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskGraphId",
-              "required": true,
-              "summary": "Identifier for the task-graph this message concerns"
-            },
-            {
-              "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
-            }
-          ],
-          "schema": "http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#",
-          "title": "Task-Graph Blocked Message",
-          "type": "topic-exchange"
-        },
-        {
-          "description": "When all tasks of a task-graph have completed successfully, the\ntask-graph is declared to be finished, and a message is posted to this\nexchange.",
-          "exchange": "task-graph-finished",
-          "name": "taskGraphFinished",
-          "routingKey": [
-            {
-              "constant": "primary",
-              "multipleWords": false,
-              "name": "routingKeyKind",
-              "required": true,
-              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "runId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerGroup",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "provisionerId",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "workerType",
-              "required": false,
-              "summary": "Always takes the value `_`"
-            },
-            {
-              "multipleWords": false,
-              "name": "schedulerId",
-              "required": true,
-              "summary": "Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production."
-            },
-            {
-              "multipleWords": false,
-              "name": "taskGraphId",
-              "required": true,
-              "summary": "Identifier for the task-graph this message concerns"
-            },
-            {
-              "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
-            }
-          ],
-          "schema": "http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#",
-          "title": "Task-Graph Finished Message",
-          "type": "topic-exchange"
-        }
-      ],
-      "exchangePrefix": "exchange/taskcluster-scheduler/v1/",
-      "title": "Scheduler AMQP Exchanges",
-      "version": 0
-    },
-    "referenceUrl": "http://references.taskcluster.net/scheduler/v1/exchanges.json"
-  },
   "Secrets": {
     "reference": {
       "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
@@ -3370,11 +3097,14 @@
         },
         {
           "args": [],
-          "description": "List the names of all secrets that you would have access to read. In\nother words, secret name `<X>` will only be returned if a) a secret\nwith name `<X>` exists, and b) you posses the scope `secrets:get:<X>`.",
+          "description": "List the names of all secrets.\n\nBy default this end-point will try to return up to 1000 secret names in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `listTaskGroup` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer.",
           "method": "get",
           "name": "list",
           "output": "http://schemas.taskcluster.net/secrets/v1/secret-list.json#",
-          "query": [],
+          "query": [
+            "continuationToken",
+            "limit"
+          ],
           "route": "/secrets",
           "stability": "stable",
           "title": "List Secrets",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'requests>=2.4.3,<3',
     'mohawk>=0.3.4,<0.4',
     'slugid>=1.0.7,<2',
-    'six>=1.10.0,<2',
+    'six>=1.10.0,<1.11',
 ]
 
 # from http://testrun.org/tox/latest/example/basic.html

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 # The VERSION variable is automagically changed
 # by release.sh.  Make sure you understand how
 # that script works if you want to change this
-VERSION = '1.3.5'
+VERSION = '2.0.0'
 
 tests_require = [
     'nose==1.3.7',

--- a/taskcluster/async/asyncclient.py
+++ b/taskcluster/async/asyncclient.py
@@ -60,7 +60,7 @@ class AsyncBaseClient(BaseClient):
         """ This function is used to dispatch calls to other functions
         for a given API Reference entry"""
 
-        routeParams, payload, query = self._processArgs(entry, *args, **kwargs)
+        routeParams, payload, query, _, _ = self._processArgs(entry, *args, **kwargs)
         route = self._subArgsInRoute(entry, routeParams)
         log.debug('Route is: %s', route)
 

--- a/taskcluster/async/asyncclient.py
+++ b/taskcluster/async/asyncclient.py
@@ -60,17 +60,8 @@ class AsyncBaseClient(BaseClient):
         """ This function is used to dispatch calls to other functions
         for a given API Reference entry"""
 
-        payload = None
-        _args = list(args)
-        _kwargs = copy.deepcopy(kwargs)
-
-        if 'input' in entry:
-            if len(args) > 0:
-                payload = _args.pop()
-            else:
-                raise exceptions.TaskclusterFailure('Payload is required as last positional arg')
-        apiArgs = self._processArgs(entry, *_args, **_kwargs)
-        route = self._subArgsInRoute(entry, apiArgs)
+        routeParams, payload, query = self._processArgs(entry, *args, **kwargs)
+        route = self._subArgsInRoute(entry, routeParams)
         log.debug('Route is: %s', route)
 
         return await self._makeHttpRequest(entry['method'], route, payload)

--- a/taskcluster/async/auth.py
+++ b/taskcluster/async/auth.py
@@ -65,7 +65,7 @@ class Auth(AsyncBaseClient):
         Get a list of all clients.  With `prefix`, only clients for which
         it is a prefix of the clientId are returned.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/list-clients-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/list-clients-response.json#``
 
         This method is ``stable``
         """
@@ -78,7 +78,7 @@ class Auth(AsyncBaseClient):
 
         Get information about a single client.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -104,7 +104,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-client-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
 
         This method is ``stable``
         """
@@ -122,7 +122,7 @@ class Auth(AsyncBaseClient):
         There is no way to retrieve an existing `accessToken`, so if you loose it
         you must reset the accessToken to acquire it again.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
 
         This method is ``stable``
         """
@@ -141,7 +141,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-client-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -158,7 +158,7 @@ class Auth(AsyncBaseClient):
         This is typically used by identity providers to re-enable clients that
         had been disabled when the corresponding identity's scopes changed.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -174,7 +174,7 @@ class Auth(AsyncBaseClient):
         This is typically used by identity providers to disable clients when the
         corresponding identity's scopes no longer satisfy the client's scopes.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -200,7 +200,7 @@ class Auth(AsyncBaseClient):
         Get a list of all roles, each role object also includes the list of
         scopes it expands to.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/list-roles-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/list-roles-response.json#``
 
         This method is ``stable``
         """
@@ -214,7 +214,7 @@ class Auth(AsyncBaseClient):
         Get information about a single role, including the set of scopes that the
         role expands to.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -234,7 +234,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-role-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -252,7 +252,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-role-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -280,7 +280,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
         This method is ``stable``
         """
@@ -295,7 +295,7 @@ class Auth(AsyncBaseClient):
         of scopes and scope restrictions (temporary credentials, assumeScopes, client scopes,
         and roles).
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
         This method is ``stable``
         """
@@ -372,7 +372,7 @@ class Auth(AsyncBaseClient):
         For details on the format returned by EC2 metadata service see:
         [EC2 User Guide](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials).
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#``
 
         This method is ``stable``
         """
@@ -385,7 +385,7 @@ class Auth(AsyncBaseClient):
 
         Retrieve a list of all Azure accounts managed by Taskcluster Auth.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#``
 
         This method is ``stable``
         """
@@ -398,7 +398,7 @@ class Auth(AsyncBaseClient):
 
         Retrieve a list of all tables in an account.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#``
 
         This method is ``stable``
         """
@@ -416,7 +416,7 @@ class Auth(AsyncBaseClient):
         which type of credentials are returned.  If level is read-write, it will create the
         table if it doesn't already exist.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#``
 
         This method is ``stable``
         """
@@ -434,7 +434,7 @@ class Auth(AsyncBaseClient):
         which type of credentials are returned.  If level is read-write, it will create the
         container if it doesn't already exist.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#``
 
         This method is ``stable``
         """
@@ -453,7 +453,7 @@ class Auth(AsyncBaseClient):
         initial team configured for this component. Contact a Sentry admin
         to have the project transferred to a team you have access to if needed
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#``
 
         This method is ``stable``
         """
@@ -468,7 +468,7 @@ class Auth(AsyncBaseClient):
 
         The token is valid for 24 hours, clients should refresh after expiration.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#``
 
         This method is ``stable``
         """
@@ -482,7 +482,7 @@ class Auth(AsyncBaseClient):
         Get temporary `token` and `id` for connecting to webhooktunnel
         The token is valid for 96 hours, clients should refresh after expiration.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#``
 
         This method is ``stable``
         """
@@ -502,7 +502,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#``
 
         This method is ``stable``
         """
@@ -527,7 +527,7 @@ class Auth(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
 
         This method is ``stable``
         """
@@ -554,7 +554,7 @@ class Auth(AsyncBaseClient):
         This method may later be extended to allow specification of client and
         required scopes via query arguments.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
 
         This method is ``stable``
         """
@@ -574,175 +574,229 @@ class Auth(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "authenticateHawk": {           'args': [],
+        "authenticateHawk": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/authenticate-hawk-request.json#',
             'method': 'post',
             'name': 'authenticateHawk',
             'output': 'http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#',
             'route': '/authenticate-hawk',
-            'stability': 'stable'},
-        "awsS3Credentials": {           'args': ['level', 'bucket', 'prefix'],
+            'stability': 'stable',
+        },
+        "awsS3Credentials": {
+            'args': ['level', 'bucket', 'prefix'],
             'method': 'get',
             'name': 'awsS3Credentials',
             'output': 'http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#',
             'query': ['format'],
             'route': '/aws/s3/<level>/<bucket>/<prefix>',
-            'stability': 'stable'},
-        "azureAccounts": {           'args': [],
+            'stability': 'stable',
+        },
+        "azureAccounts": {
+            'args': [],
             'method': 'get',
             'name': 'azureAccounts',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#',
             'route': '/azure/accounts',
-            'stability': 'stable'},
-        "azureBlobSAS": {           'args': ['account', 'container', 'level'],
+            'stability': 'stable',
+        },
+        "azureBlobSAS": {
+            'args': ['account', 'container', 'level'],
             'method': 'get',
             'name': 'azureBlobSAS',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#',
             'route': '/azure/<account>/containers/<container>/<level>',
-            'stability': 'stable'},
-        "azureTableSAS": {           'args': ['account', 'table', 'level'],
+            'stability': 'stable',
+        },
+        "azureTableSAS": {
+            'args': ['account', 'table', 'level'],
             'method': 'get',
             'name': 'azureTableSAS',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#',
             'route': '/azure/<account>/table/<table>/<level>',
-            'stability': 'stable'},
-        "azureTables": {           'args': ['account'],
+            'stability': 'stable',
+        },
+        "azureTables": {
+            'args': ['account'],
             'method': 'get',
             'name': 'azureTables',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#',
             'query': ['continuationToken'],
             'route': '/azure/<account>/tables',
-            'stability': 'stable'},
-        "client": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "client": {
+            'args': ['clientId'],
             'method': 'get',
             'name': 'client',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "createClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "createClient": {
+            'args': ['clientId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-client-request.json#',
             'method': 'put',
             'name': 'createClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/create-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "createRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "createRole": {
+            'args': ['roleId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-role-request.json#',
             'method': 'put',
             'name': 'createRole',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "currentScopes": {           'args': [],
+            'stability': 'stable',
+        },
+        "currentScopes": {
+            'args': [],
             'method': 'get',
             'name': 'currentScopes',
             'output': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'route': '/scopes/current',
-            'stability': 'stable'},
-        "deleteClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "deleteClient": {
+            'args': ['clientId'],
             'method': 'delete',
             'name': 'deleteClient',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "deleteRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "deleteRole": {
+            'args': ['roleId'],
             'method': 'delete',
             'name': 'deleteRole',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "disableClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "disableClient": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'disableClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>/disable',
-            'stability': 'stable'},
-        "enableClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "enableClient": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'enableClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>/enable',
-            'stability': 'stable'},
-        "expandScopes": {           'args': [],
+            'stability': 'stable',
+        },
+        "expandScopes": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'method': 'get',
             'name': 'expandScopes',
             'output': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'route': '/scopes/expand',
-            'stability': 'stable'},
-        "listClients": {           'args': [],
+            'stability': 'stable',
+        },
+        "listClients": {
+            'args': [],
             'method': 'get',
             'name': 'listClients',
             'output': 'http://schemas.taskcluster.net/auth/v1/list-clients-response.json#',
             'query': ['prefix'],
             'route': '/clients/',
-            'stability': 'stable'},
-        "listRoles": {           'args': [],
+            'stability': 'stable',
+        },
+        "listRoles": {
+            'args': [],
             'method': 'get',
             'name': 'listRoles',
             'output': 'http://schemas.taskcluster.net/auth/v1/list-roles-response.json#',
             'route': '/roles/',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "resetAccessToken": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "resetAccessToken": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'resetAccessToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/create-client-response.json#',
             'route': '/clients/<clientId>/reset',
-            'stability': 'stable'},
-        "role": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "role": {
+            'args': ['roleId'],
             'method': 'get',
             'name': 'role',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "sentryDSN": {           'args': ['project'],
+            'stability': 'stable',
+        },
+        "sentryDSN": {
+            'args': ['project'],
             'method': 'get',
             'name': 'sentryDSN',
             'output': 'http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#',
             'route': '/sentry/<project>/dsn',
-            'stability': 'stable'},
-        "statsumToken": {           'args': ['project'],
+            'stability': 'stable',
+        },
+        "statsumToken": {
+            'args': ['project'],
             'method': 'get',
             'name': 'statsumToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#',
             'route': '/statsum/<project>/token',
-            'stability': 'stable'},
-        "testAuthenticate": {           'args': [],
+            'stability': 'stable',
+        },
+        "testAuthenticate": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-request.json#',
             'method': 'post',
             'name': 'testAuthenticate',
             'output': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#',
             'route': '/test-authenticate',
-            'stability': 'stable'},
-        "testAuthenticateGet": {           'args': [],
+            'stability': 'stable',
+        },
+        "testAuthenticateGet": {
+            'args': [],
             'method': 'get',
             'name': 'testAuthenticateGet',
             'output': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#',
             'route': '/test-authenticate-get/',
-            'stability': 'stable'},
-        "updateClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "updateClient": {
+            'args': ['clientId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-client-request.json#',
             'method': 'post',
             'name': 'updateClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "updateRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "updateRole": {
+            'args': ['roleId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-role-request.json#',
             'method': 'post',
             'name': 'updateRole',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "webhooktunnelToken": {           'args': [],
+            'stability': 'stable',
+        },
+        "webhooktunnelToken": {
+            'args': [],
             'method': 'get',
             'name': 'webhooktunnelToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#',
             'route': '/webhooktunnel',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/authevents.py
+++ b/taskcluster/async/authevents.py
@@ -27,83 +27,149 @@ class AuthEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-auth/v1/"
     }
 
-    """
-    Client Created Messages
-
-    Message that a new client has been created.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def clientCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-created', 'name': 'clientCreated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Created Messages
 
-    """
-    Client Updated Messages
+        Message that a new client has been created.
 
-    Message that a new client has been updated.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-created',
+            'name': 'clientCreated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def clientUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-updated', 'name': 'clientUpdated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Updated Messages
 
-    """
-    Client Deleted Messages
+        Message that a new client has been updated.
 
-    Message that a new client has been deleted.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-updated',
+            'name': 'clientUpdated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def clientDeleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-deleted', 'name': 'clientDeleted', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Deleted Messages
 
-    """
-    Role Created Messages
+        Message that a new client has been deleted.
 
-    Message that a new role has been created.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-deleted',
+            'name': 'clientDeleted',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-created', 'name': 'roleCreated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Created Messages
 
-    """
-    Role Updated Messages
+        Message that a new role has been created.
 
-    Message that a new role has been updated.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'role-created',
+            'name': 'roleCreated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-updated', 'name': 'roleUpdated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Updated Messages
 
-    """
-    Role Deleted Messages
+        Message that a new role has been updated.
 
-    Message that a new role has been deleted.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'role-updated',
+            'name': 'roleUpdated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleDeleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-deleted', 'name': 'roleDeleted', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Deleted Messages
+
+        Message that a new role has been deleted.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'role-deleted',
+            'name': 'roleDeleted',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/awsprovisioner.py
+++ b/taskcluster/async/awsprovisioner.py
@@ -56,7 +56,7 @@ class AwsProvisioner(AsyncBaseClient):
         there may be running EC2 instances for deleted worker types that are not
         included here.  The list is unordered.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#``
 
         This method is ``stable``
         """
@@ -93,7 +93,7 @@ class AwsProvisioner(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -118,7 +118,7 @@ class AwsProvisioner(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -135,7 +135,7 @@ class AwsProvisioner(AsyncBaseClient):
         If the worker type definition has not been changed, the date
         should be identical as it is the same stored value.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#``
 
         This method is ``stable``
         """
@@ -152,7 +152,7 @@ class AwsProvisioner(AsyncBaseClient):
         use the results of this method to submit date to the update
         method.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -188,7 +188,7 @@ class AwsProvisioner(AsyncBaseClient):
         not include worker types which are left overs from a deleted worker
         type definition but are still running in AWS.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#``
 
         This method is ``stable``
         """
@@ -225,7 +225,7 @@ class AwsProvisioner(AsyncBaseClient):
         or else the secrets will be visible to any process which can access the
         user data associated with the instance.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#``
 
         This method is ``stable``
         """
@@ -273,7 +273,7 @@ class AwsProvisioner(AsyncBaseClient):
 
         **This API end-point is experimental and may be subject to change without warning.**
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#``
 
         This method is ``experimental``
         """
@@ -306,7 +306,7 @@ class AwsProvisioner(AsyncBaseClient):
 
         **Warning** this api end-point is **not stable**.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#``
 
         This method is ``experimental``
         """
@@ -326,93 +326,123 @@ class AwsProvisioner(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "backendStatus": {           'args': [],
+        "backendStatus": {
+            'args': [],
             'method': 'get',
             'name': 'backendStatus',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#',
             'route': '/backend-status',
-            'stability': 'experimental'},
-        "createSecret": {           'args': ['token'],
+            'stability': 'experimental',
+        },
+        "createSecret": {
+            'args': ['token'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-secret-request.json#',
             'method': 'put',
             'name': 'createSecret',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "createWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "createWorkerType": {
+            'args': ['workerType'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#',
             'method': 'put',
             'name': 'createWorkerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "getLaunchSpecs": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "getLaunchSpecs": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'getLaunchSpecs',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#',
             'route': '/worker-type/<workerType>/launch-specifications',
-            'stability': 'experimental'},
-        "getSecret": {           'args': ['token'],
+            'stability': 'experimental',
+        },
+        "getSecret": {
+            'args': ['token'],
             'method': 'get',
             'name': 'getSecret',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "instanceStarted": {           'args': ['instanceId', 'token'],
+            'stability': 'stable',
+        },
+        "instanceStarted": {
+            'args': ['instanceId', 'token'],
             'method': 'get',
             'name': 'instanceStarted',
             'route': '/instance-started/<instanceId>/<token>',
-            'stability': 'stable'},
-        "listWorkerTypeSummaries": {           'args': [],
+            'stability': 'stable',
+        },
+        "listWorkerTypeSummaries": {
+            'args': [],
             'method': 'get',
             'name': 'listWorkerTypeSummaries',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#',
             'route': '/list-worker-type-summaries',
-            'stability': 'stable'},
-        "listWorkerTypes": {           'args': [],
+            'stability': 'stable',
+        },
+        "listWorkerTypes": {
+            'args': [],
             'method': 'get',
             'name': 'listWorkerTypes',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#',
             'route': '/list-worker-types',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "removeSecret": {           'args': ['token'],
+            'stability': 'stable',
+        },
+        "removeSecret": {
+            'args': ['token'],
             'method': 'delete',
             'name': 'removeSecret',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "removeWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "removeWorkerType": {
+            'args': ['workerType'],
             'method': 'delete',
             'name': 'removeWorkerType',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "state": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "state": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'state',
             'route': '/state/<workerType>',
-            'stability': 'stable'},
-        "updateWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "updateWorkerType": {
+            'args': ['workerType'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#',
             'method': 'post',
             'name': 'updateWorkerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>/update',
-            'stability': 'stable'},
-        "workerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "workerType": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'workerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "workerTypeLastModified": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "workerTypeLastModified": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeLastModified',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#',
             'route': '/worker-type-last-modified/<workerType>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/awsprovisionerevents.py
+++ b/taskcluster/async/awsprovisionerevents.py
@@ -20,59 +20,119 @@ class AwsProvisionerEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/"
     }
 
-    """
-    WorkerType Created Message
-
-    When a new `workerType` is created a message will be published to this
-    exchange.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * workerType: WorkerType that this message concerns. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def workerTypeCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-created', 'name': 'workerTypeCreated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Created Message
 
-    """
-    WorkerType Updated Message
+        When a new `workerType` is created a message will be published to this
+        exchange.
 
-    When a `workerType` is updated a message will be published to this
-    exchange.
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerType: WorkerType that this message concerns. (required)
 
-     * workerType: WorkerType that this message concerns. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'worker-type-created',
+            'name': 'workerTypeCreated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def workerTypeUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-updated', 'name': 'workerTypeUpdated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Updated Message
 
-    """
-    WorkerType Removed Message
+        When a `workerType` is updated a message will be published to this
+        exchange.
 
-    When a `workerType` is removed a message will be published to this
-    exchange.
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerType: WorkerType that this message concerns. (required)
 
-     * workerType: WorkerType that this message concerns. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'worker-type-updated',
+            'name': 'workerTypeUpdated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def workerTypeRemoved(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-removed', 'name': 'workerTypeRemoved', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Removed Message
+
+        When a `workerType` is removed a message will be published to this
+        exchange.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * workerType: WorkerType that this message concerns. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-type-removed',
+            'name': 'workerTypeRemoved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/github.py
+++ b/taskcluster/async/github.py
@@ -48,7 +48,7 @@ class Github(AsyncBaseClient):
         Taskcluster. Can be filtered on various git-specific
         fields.
 
-        This method takes output: ``http://schemas.taskcluster.net/github/v1/build-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/github/v1/build-list.json#``
 
         This method is ``experimental``
         """
@@ -74,7 +74,7 @@ class Github(AsyncBaseClient):
         Returns any repository metadata that is
         useful within Taskcluster related services.
 
-        This method takes output: ``http://schemas.taskcluster.net/github/v1/repository.json``
+        This method gives output: ``http://schemas.taskcluster.net/github/v1/repository.json``
 
         This method is ``experimental``
         """
@@ -138,55 +138,67 @@ class Github(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "badge": {           'args': ['owner', 'repo', 'branch'],
+        "badge": {
+            'args': ['owner', 'repo', 'branch'],
             'method': 'get',
             'name': 'badge',
             'route': '/repository/<owner>/<repo>/<branch>/badge.svg',
-            'stability': 'experimental'},
-        "builds": {           'args': [],
+            'stability': 'experimental',
+        },
+        "builds": {
+            'args': [],
             'method': 'get',
             'name': 'builds',
             'output': 'http://schemas.taskcluster.net/github/v1/build-list.json#',
-            'query': [           'continuationToken',
-                                 'limit',
-                                 'organization',
-                                 'repository',
-                                 'sha'],
+            'query': ['continuationToken', 'limit', 'organization', 'repository', 'sha'],
             'route': '/builds',
-            'stability': 'experimental'},
-        "createComment": {           'args': ['owner', 'repo', 'number'],
+            'stability': 'experimental',
+        },
+        "createComment": {
+            'args': ['owner', 'repo', 'number'],
             'input': 'http://schemas.taskcluster.net/github/v1/create-comment.json',
             'method': 'post',
             'name': 'createComment',
             'route': '/repository/<owner>/<repo>/issues/<number>/comments',
-            'stability': 'experimental'},
-        "createStatus": {           'args': ['owner', 'repo', 'sha'],
+            'stability': 'experimental',
+        },
+        "createStatus": {
+            'args': ['owner', 'repo', 'sha'],
             'input': 'http://schemas.taskcluster.net/github/v1/create-status.json',
             'method': 'post',
             'name': 'createStatus',
             'route': '/repository/<owner>/<repo>/statuses/<sha>',
-            'stability': 'experimental'},
-        "githubWebHookConsumer": {           'args': [],
+            'stability': 'experimental',
+        },
+        "githubWebHookConsumer": {
+            'args': [],
             'method': 'post',
             'name': 'githubWebHookConsumer',
             'route': '/github',
-            'stability': 'experimental'},
-        "latest": {           'args': ['owner', 'repo', 'branch'],
+            'stability': 'experimental',
+        },
+        "latest": {
+            'args': ['owner', 'repo', 'branch'],
             'method': 'get',
             'name': 'latest',
             'route': '/repository/<owner>/<repo>/<branch>/latest',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "repository": {           'args': ['owner', 'repo'],
+            'stability': 'stable',
+        },
+        "repository": {
+            'args': ['owner', 'repo'],
             'method': 'get',
             'name': 'repository',
             'output': 'http://schemas.taskcluster.net/github/v1/repository.json',
             'route': '/repository/<owner>/<repo>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/async/githubevents.py
+++ b/taskcluster/async/githubevents.py
@@ -25,64 +25,128 @@ class GithubEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-github/v1/"
     }
 
-    """
-    GitHub Pull Request Event
-
-    When a GitHub pull request event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
-
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-
-     * action: The GitHub `action` which triggered an event. See for possible values see the payload actions property. (required)
-    """
-
     def pullRequest(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'pull-request', 'name': 'pullRequest', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'action', 'required': True, 'summary': 'The GitHub `action` which triggered an event. See for possible values see the payload actions property.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#'}, *args, **kwargs)
+        """
+        GitHub Pull Request Event
 
-    """
-    GitHub push Event
+        When a GitHub pull request event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
 
-    When a GitHub push event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-push-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-    """
+         * action: The GitHub `action` which triggered an event. See for possible values see the payload actions property. (required)
+        """
+
+        ref = {
+            'exchange': 'pull-request',
+            'name': 'pullRequest',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'action',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def push(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'push', 'name': 'push', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-push-message.json#'}, *args, **kwargs)
+        """
+        GitHub push Event
 
-    """
-    GitHub release Event
+        When a GitHub push event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
 
-    When a GitHub release event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-push-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-release-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+        """
 
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-    """
+        ref = {
+            'exchange': 'push',
+            'name': 'push',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-push-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def release(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'release', 'name': 'release', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-release-message.json#'}, *args, **kwargs)
+        """
+        GitHub release Event
+
+        When a GitHub release event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-release-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+        """
+
+        ref = {
+            'exchange': 'release',
+            'name': 'release',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-release-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/hooks.py
+++ b/taskcluster/async/hooks.py
@@ -40,7 +40,7 @@ class Hooks(AsyncBaseClient):
 
         This endpoint will return a list of all hook groups with at least one hook.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json``
 
         This method is ``experimental``
         """
@@ -54,7 +54,7 @@ class Hooks(AsyncBaseClient):
         This endpoint will return a list of all the hook definitions within a
         given hook group.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json``
 
         This method is ``experimental``
         """
@@ -68,7 +68,7 @@ class Hooks(AsyncBaseClient):
         This endpoint will return the hook definition for the given `hookGroupId`
         and hookId.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -82,7 +82,7 @@ class Hooks(AsyncBaseClient):
         This endpoint will return the current status of the hook.  This represents a
         snapshot in time and may vary from one call to the next.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-status.json``
 
         This method is ``experimental``
         """
@@ -96,7 +96,7 @@ class Hooks(AsyncBaseClient):
         This endpoint will return the schedule and next scheduled creation time
         for the given hook.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-schedule.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-schedule.json``
 
         This method is ``deprecated``
         """
@@ -116,7 +116,7 @@ class Hooks(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/create-hook-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -132,7 +132,7 @@ class Hooks(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/create-hook-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -158,7 +158,7 @@ class Hooks(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/trigger-payload.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
 
         This method is ``experimental``
         """
@@ -172,7 +172,7 @@ class Hooks(AsyncBaseClient):
         Retrieve a unique secret token for triggering the specified hook. This
         token can be deactivated with `resetTriggerToken`.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
 
         This method is ``experimental``
         """
@@ -186,7 +186,7 @@ class Hooks(AsyncBaseClient):
         Reset the token for triggering a given hook. This invalidates token that
         may have been issued via getTriggerToken with a new token.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
 
         This method is ``experimental``
         """
@@ -201,7 +201,7 @@ class Hooks(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/trigger-payload.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
 
         This method is ``experimental``
         """
@@ -221,86 +221,112 @@ class Hooks(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "createHook": {           'args': ['hookGroupId', 'hookId'],
+        "createHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/create-hook-request.json',
             'method': 'put',
             'name': 'createHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "getHookSchedule": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "getHookSchedule": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getHookSchedule',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-schedule.json',
             'route': '/hooks/<hookGroupId>/<hookId>/schedule',
-            'stability': 'deprecated'},
-        "getHookStatus": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'deprecated',
+        },
+        "getHookStatus": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getHookStatus',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/status',
-            'stability': 'experimental'},
-        "getTriggerToken": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "getTriggerToken": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getTriggerToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json',
             'route': '/hooks/<hookGroupId>/<hookId>/token',
-            'stability': 'experimental'},
-        "hook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "hook": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'hook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "listHookGroups": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listHookGroups": {
+            'args': [],
             'method': 'get',
             'name': 'listHookGroups',
             'output': 'http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json',
             'route': '/hooks',
-            'stability': 'experimental'},
-        "listHooks": {           'args': ['hookGroupId'],
+            'stability': 'experimental',
+        },
+        "listHooks": {
+            'args': ['hookGroupId'],
             'method': 'get',
             'name': 'listHooks',
             'output': 'http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json',
             'route': '/hooks/<hookGroupId>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "removeHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'stable',
+        },
+        "removeHook": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'delete',
             'name': 'removeHook',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "resetTriggerToken": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "resetTriggerToken": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'post',
             'name': 'resetTriggerToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json',
             'route': '/hooks/<hookGroupId>/<hookId>/token',
-            'stability': 'experimental'},
-        "triggerHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "triggerHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/trigger-payload.json',
             'method': 'post',
             'name': 'triggerHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/task-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/trigger',
-            'stability': 'experimental'},
-        "triggerHookWithToken": {           'args': ['hookGroupId', 'hookId', 'token'],
+            'stability': 'experimental',
+        },
+        "triggerHookWithToken": {
+            'args': ['hookGroupId', 'hookId', 'token'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/trigger-payload.json',
             'method': 'post',
             'name': 'triggerHookWithToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/task-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/trigger/<token>',
-            'stability': 'experimental'},
-        "updateHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "updateHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/create-hook-request.json',
             'method': 'post',
             'name': 'updateHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/async/index.py
+++ b/taskcluster/async/index.py
@@ -118,7 +118,7 @@ class Index(AsyncBaseClient):
         Find a task by index path, returning the highest-rank task with that path. If no
         task exists for the given path, this API end-point will respond with a 404 status.
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
 
         This method is ``stable``
         """
@@ -139,7 +139,7 @@ class Index(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/list-namespaces-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#``
 
         This method is ``stable``
         """
@@ -163,7 +163,7 @@ class Index(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/list-tasks-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/list-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/list-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -182,7 +182,7 @@ class Index(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/insert-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
 
         This method is ``stable``
         """
@@ -226,43 +226,55 @@ class Index(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "findArtifactFromTask": {           'args': ['indexPath', 'name'],
+        "findArtifactFromTask": {
+            'args': ['indexPath', 'name'],
             'method': 'get',
             'name': 'findArtifactFromTask',
             'route': '/task/<indexPath>/artifacts/<name>',
-            'stability': 'stable'},
-        "findTask": {           'args': ['indexPath'],
+            'stability': 'stable',
+        },
+        "findTask": {
+            'args': ['indexPath'],
             'method': 'get',
             'name': 'findTask',
             'output': 'http://schemas.taskcluster.net/index/v1/indexed-task-response.json#',
             'route': '/task/<indexPath>',
-            'stability': 'stable'},
-        "insertTask": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "insertTask": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/insert-task-request.json#',
             'method': 'put',
             'name': 'insertTask',
             'output': 'http://schemas.taskcluster.net/index/v1/indexed-task-response.json#',
             'route': '/task/<namespace>',
-            'stability': 'stable'},
-        "listNamespaces": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "listNamespaces": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/list-namespaces-request.json#',
             'method': 'post',
             'name': 'listNamespaces',
             'output': 'http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#',
             'route': '/namespaces/<namespace>',
-            'stability': 'stable'},
-        "listTasks": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "listTasks": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/list-tasks-request.json#',
             'method': 'post',
             'name': 'listTasks',
             'output': 'http://schemas.taskcluster.net/index/v1/list-tasks-response.json#',
             'route': '/tasks/<namespace>',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/login.py
+++ b/taskcluster/async/login.py
@@ -47,7 +47,7 @@ class Login(AsyncBaseClient):
         monitor this expiration and refresh the credentials if necessary, by calling
         this endpoint again, if they have expired.
 
-        This method takes output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
 
         This method is ``experimental``
         """
@@ -67,17 +67,21 @@ class Login(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "oidcCredentials": {           'args': ['provider'],
+        "oidcCredentials": {
+            'args': ['provider'],
             'method': 'get',
             'name': 'oidcCredentials',
             'output': 'http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json',
             'route': '/oidc-credentials/<provider>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/notify.py
+++ b/taskcluster/async/notify.py
@@ -87,29 +87,37 @@ class Notify(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "email": {           'args': [],
+        "email": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/email-request.json',
             'method': 'post',
             'name': 'email',
             'route': '/email',
-            'stability': 'experimental'},
-        "irc": {           'args': [],
+            'stability': 'experimental',
+        },
+        "irc": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/irc-request.json',
             'method': 'post',
             'name': 'irc',
             'route': '/irc',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "pulse": {           'args': [],
+            'stability': 'stable',
+        },
+        "pulse": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/pulse-request.json',
             'method': 'post',
             'name': 'pulse',
             'route': '/pulse',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/async/pulse.py
+++ b/taskcluster/async/pulse.py
@@ -31,7 +31,7 @@ class Pulse(AsyncBaseClient):
 
         Get an overview of the Rabbit cluster.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
 
         This method is ``experimental``
         """
@@ -48,7 +48,7 @@ class Pulse(AsyncBaseClient):
         `continuationToken` will be returned, which can be given in the next
         request. For the initial request, do not provide continuation.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
 
         This method is ``experimental``
         """
@@ -62,7 +62,7 @@ class Pulse(AsyncBaseClient):
         Get public information about a single namespace. This is the same information
         as returned by `listNamespaces`.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
 
         This method is ``experimental``
         """
@@ -84,7 +84,7 @@ class Pulse(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/pulse/v1/namespace-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
 
         This method is ``experimental``
         """
@@ -104,37 +104,47 @@ class Pulse(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "claimNamespace": {           'args': ['namespace'],
+        "claimNamespace": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/pulse/v1/namespace-request.json',
             'method': 'post',
             'name': 'claimNamespace',
             'output': 'http://schemas.taskcluster.net/pulse/v1/namespace-response.json',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental'},
-        "listNamespaces": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listNamespaces": {
+            'args': [],
             'method': 'get',
             'name': 'listNamespaces',
             'output': 'http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json',
             'query': ['limit', 'continuation'],
             'route': '/namespaces',
-            'stability': 'experimental'},
-        "namespace": {           'args': ['namespace'],
+            'stability': 'experimental',
+        },
+        "namespace": {
+            'args': ['namespace'],
             'method': 'get',
             'name': 'namespace',
             'output': 'http://schemas.taskcluster.net/pulse/v1/namespace.json',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental'},
-        "overview": {           'args': [],
+            'stability': 'experimental',
+        },
+        "overview": {
+            'args': [],
             'method': 'get',
             'name': 'overview',
             'output': 'http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json',
             'route': '/overview',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/purgecache.py
+++ b/taskcluster/async/purgecache.py
@@ -50,7 +50,7 @@ class PurgeCache(AsyncBaseClient):
         endpoint that is specific to their workerType and
         provisionerId.
 
-        This method takes output: ``http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#``
 
         This method is ``experimental``
         """
@@ -65,7 +65,7 @@ class PurgeCache(AsyncBaseClient):
         a certain time. This is safe to be used in automation from
         workers.
 
-        This method takes output: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#``
 
         This method is ``experimental``
         """
@@ -85,31 +85,39 @@ class PurgeCache(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "allPurgeRequests": {           'args': [],
+        "allPurgeRequests": {
+            'args': [],
             'method': 'get',
             'name': 'allPurgeRequests',
             'output': 'http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/purge-cache/list',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "purgeCache": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "purgeCache": {
+            'args': ['provisionerId', 'workerType'],
             'input': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request.json#',
             'method': 'post',
             'name': 'purgeCache',
             'route': '/purge-cache/<provisionerId>/<workerType>',
-            'stability': 'experimental'},
-        "purgeRequests": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "purgeRequests": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'purgeRequests',
             'output': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#',
             'query': ['since'],
             'route': '/purge-cache/<provisionerId>/<workerType>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/async/purgecacheevents.py
+++ b/taskcluster/async/purgecacheevents.py
@@ -25,24 +25,44 @@ class PurgeCacheEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-purge-cache/v1/"
     }
 
-    """
-    Purge Cache Messages
-
-    When a cache purge is requested  a message will be posted on this
-    exchange with designated `provisionerId` and `workerType` in the
-    routing-key and the name of the `cacheFolder` as payload
-
-    This exchange outputs: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * provisionerId: `provisionerId` under which to purge cache. (required)
-
-     * workerType: `workerType` for which to purge cache. (required)
-    """
-
     def purgeCache(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'purge-cache', 'name': 'purgeCache', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` under which to purge cache.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` for which to purge cache.'}], 'schema': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#'}, *args, **kwargs)
+        """
+        Purge Cache Messages
+
+        When a cache purge is requested  a message will be posted on this
+        exchange with designated `provisionerId` and `workerType` in the
+        routing-key and the name of the `cacheFolder` as payload
+
+        This exchange outputs: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * provisionerId: `provisionerId` under which to purge cache. (required)
+
+         * workerType: `workerType` for which to purge cache. (required)
+        """
+
+        ref = {
+            'exchange': 'purge-cache',
+            'name': 'purgeCache',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/queue.py
+++ b/taskcluster/async/queue.py
@@ -36,7 +36,7 @@ class Queue(AsyncBaseClient):
         definition may have been modified by queue, if an optional property is
         not specified the queue may provide a default value.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task.json#``
 
         This method is ``stable``
         """
@@ -49,7 +49,7 @@ class Queue(AsyncBaseClient):
 
         Get task status structure from `taskId`
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -77,7 +77,7 @@ class Queue(AsyncBaseClient):
         If you are not interested in listing all the members at once, you may
         use the query-string option `limit` to return fewer.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#``
 
         This method is ``stable``
         """
@@ -105,7 +105,7 @@ class Queue(AsyncBaseClient):
         If you are not interested in listing all the tasks at once, you may
         use the query-string option `limit` to return fewer.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -143,7 +143,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/create-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -159,7 +159,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/create-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``deprecated``
         """
@@ -185,7 +185,7 @@ class Queue(AsyncBaseClient):
         if called with a `taskId` that is already scheduled, or even resolved.
         To reschedule a task previously resolved, use `rerunTask`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -209,7 +209,7 @@ class Queue(AsyncBaseClient):
         is not either `failed` or `completed`, this operation will just return
         the current task status.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``deprecated``
         """
@@ -233,7 +233,7 @@ class Queue(AsyncBaseClient):
         isn't `unscheduled`, `pending` or `running`, this operation will just
         return the current task status.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -248,7 +248,7 @@ class Queue(AsyncBaseClient):
         Once messages are polled from here, you can claim the referenced task
         with `claimTask`, and afterwards you should always delete the message.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#``
 
         This method is ``stable``
         """
@@ -263,7 +263,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/claim-work-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/claim-work-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/claim-work-response.json#``
 
         This method is ``stable``
         """
@@ -278,7 +278,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/task-claim-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-claim-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-claim-response.json#``
 
         This method is ``stable``
         """
@@ -311,7 +311,7 @@ class Queue(AsyncBaseClient):
         should abort the task and forget about the given `runId`. There is no
         need to resolve the run or upload artifacts.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#``
 
         This method is ``stable``
         """
@@ -324,7 +324,7 @@ class Queue(AsyncBaseClient):
 
         Report a task completed, resolving the run as `completed`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -343,7 +343,7 @@ class Queue(AsyncBaseClient):
         payload, or other unexpected condition. In these cases we have a task
         exception, which should be reported with `reportException`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -370,7 +370,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/task-exception-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -442,7 +442,7 @@ class Queue(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#``
 
         This method is ``stable``
         """
@@ -516,7 +516,7 @@ class Queue(AsyncBaseClient):
         By default this end-point will list up-to 1000 artifacts in a single page
         you may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
 
         This method is ``experimental``
         """
@@ -538,7 +538,7 @@ class Queue(AsyncBaseClient):
         By default this end-point will list up-to 1000 artifacts in a single page
         you may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
 
         This method is ``experimental``
         """
@@ -560,7 +560,7 @@ class Queue(AsyncBaseClient):
         option. By default this end-point will list up to 1000 provisioners in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#``
 
         This method is ``experimental``
         """
@@ -579,7 +579,7 @@ class Queue(AsyncBaseClient):
         should be no means expect this to be an accurate number.
         It is, however, a solid estimate of the number of pending tasks.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -597,7 +597,7 @@ class Queue(AsyncBaseClient):
         option. By default this end-point will list up to 1000 worker-types in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#``
 
         This method is ``experimental``
         """
@@ -615,7 +615,7 @@ class Queue(AsyncBaseClient):
         option. By default this end-point will list up to 1000 workers in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-workers-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-workers-response.json#``
 
         This method is ``experimental``
         """
@@ -635,172 +635,224 @@ class Queue(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "cancelTask": {           'args': ['taskId'],
+        "cancelTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'cancelTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/cancel',
-            'stability': 'stable'},
-        "claimTask": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "claimTask": {
+            'args': ['taskId', 'runId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/task-claim-request.json#',
             'method': 'post',
             'name': 'claimTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-claim-response.json#',
             'route': '/task/<taskId>/runs/<runId>/claim',
-            'stability': 'stable'},
-        "claimWork": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "claimWork": {
+            'args': ['provisionerId', 'workerType'],
             'input': 'http://schemas.taskcluster.net/queue/v1/claim-work-request.json#',
             'method': 'post',
             'name': 'claimWork',
             'output': 'http://schemas.taskcluster.net/queue/v1/claim-work-response.json#',
             'route': '/claim-work/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "createArtifact": {           'args': ['taskId', 'runId', 'name'],
+            'stability': 'stable',
+        },
+        "createArtifact": {
+            'args': ['taskId', 'runId', 'name'],
             'input': 'http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#',
             'method': 'post',
             'name': 'createArtifact',
             'output': 'http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#',
             'route': '/task/<taskId>/runs/<runId>/artifacts/<name>',
-            'stability': 'stable'},
-        "createTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "createTask": {
+            'args': ['taskId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/create-task-request.json#',
             'method': 'put',
             'name': 'createTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>',
-            'stability': 'stable'},
-        "defineTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "defineTask": {
+            'args': ['taskId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/create-task-request.json#',
             'method': 'post',
             'name': 'defineTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/define',
-            'stability': 'deprecated'},
-        "getArtifact": {           'args': ['taskId', 'runId', 'name'],
+            'stability': 'deprecated',
+        },
+        "getArtifact": {
+            'args': ['taskId', 'runId', 'name'],
             'method': 'get',
             'name': 'getArtifact',
             'route': '/task/<taskId>/runs/<runId>/artifacts/<name>',
-            'stability': 'stable'},
-        "getLatestArtifact": {           'args': ['taskId', 'name'],
+            'stability': 'stable',
+        },
+        "getLatestArtifact": {
+            'args': ['taskId', 'name'],
             'method': 'get',
             'name': 'getLatestArtifact',
             'route': '/task/<taskId>/artifacts/<name>',
-            'stability': 'stable'},
-        "listArtifacts": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "listArtifacts": {
+            'args': ['taskId', 'runId'],
             'method': 'get',
             'name': 'listArtifacts',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/runs/<runId>/artifacts',
-            'stability': 'experimental'},
-        "listDependentTasks": {           'args': ['taskId'],
+            'stability': 'experimental',
+        },
+        "listDependentTasks": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'listDependentTasks',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/dependents',
-            'stability': 'stable'},
-        "listLatestArtifacts": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "listLatestArtifacts": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'listLatestArtifacts',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/artifacts',
-            'stability': 'experimental'},
-        "listProvisioners": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listProvisioners": {
+            'args': [],
             'method': 'get',
             'name': 'listProvisioners',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners',
-            'stability': 'experimental'},
-        "listTaskGroup": {           'args': ['taskGroupId'],
+            'stability': 'experimental',
+        },
+        "listTaskGroup": {
+            'args': ['taskGroupId'],
             'method': 'get',
             'name': 'listTaskGroup',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task-group/<taskGroupId>/list',
-            'stability': 'stable'},
-        "listWorkerTypes": {           'args': ['provisionerId'],
+            'stability': 'stable',
+        },
+        "listWorkerTypes": {
+            'args': ['provisionerId'],
             'method': 'get',
             'name': 'listWorkerTypes',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners/<provisionerId>/worker-types',
-            'stability': 'experimental'},
-        "listWorkers": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "listWorkers": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'listWorkers',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-workers-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners/<provisionerId>/worker-types/<workerType>/workers',
-            'stability': 'experimental'},
-        "pendingTasks": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "pendingTasks": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'pendingTasks',
             'output': 'http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#',
             'route': '/pending/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "pollTaskUrls": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "pollTaskUrls": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'pollTaskUrls',
             'output': 'http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#',
             'route': '/poll-task-url/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "reclaimTask": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reclaimTask": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reclaimTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#',
             'route': '/task/<taskId>/runs/<runId>/reclaim',
-            'stability': 'stable'},
-        "reportCompleted": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportCompleted": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reportCompleted',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/completed',
-            'stability': 'stable'},
-        "reportException": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportException": {
+            'args': ['taskId', 'runId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/task-exception-request.json#',
             'method': 'post',
             'name': 'reportException',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/exception',
-            'stability': 'stable'},
-        "reportFailed": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportFailed": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reportFailed',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/failed',
-            'stability': 'stable'},
-        "rerunTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "rerunTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'rerunTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/rerun',
-            'stability': 'deprecated'},
-        "scheduleTask": {           'args': ['taskId'],
+            'stability': 'deprecated',
+        },
+        "scheduleTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'scheduleTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/schedule',
-            'stability': 'stable'},
-        "status": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "status": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'status',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/status',
-            'stability': 'stable'},
-        "task": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "task": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'task',
             'output': 'http://schemas.taskcluster.net/queue/v1/task.json#',
             'route': '/task/<taskId>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/queueevents.py
+++ b/taskcluster/async/queueevents.py
@@ -66,288 +66,648 @@ class QueueEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-queue/v1/"
     }
 
-    """
-    Task Defined Messages
-
-    When a task is created or just defined a message is posted to this
-    exchange.
-
-    This message exchange is mainly useful when tasks are scheduled by a
-    scheduler that uses `defineTask` as this does not make the task
-    `pending`. Thus, no `taskPending` message is published.
-    Please, note that messages are also published on this exchange if defined
-    using `createTask`.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-defined-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * taskId: `taskId` for the task this message concerns (required)
-
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
-
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
-
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
-
-     * provisionerId: `provisionerId` this task is targeted at. (required)
-
-     * workerType: `workerType` this task must run on. (required)
-
-     * schedulerId: `schedulerId` this task was created by. (required)
-
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def taskDefined(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-defined', 'name': 'taskDefined', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-defined-message.json#'}, *args, **kwargs)
+        """
+        Task Defined Messages
 
-    """
-    Task Pending Messages
+        When a task is created or just defined a message is posted to this
+        exchange.
 
-    When a task becomes `pending` a message is posted to this exchange.
+        This message exchange is mainly useful when tasks are scheduled by a
+        scheduler that uses `defineTask` as this does not make the task
+        `pending`. Thus, no `taskPending` message is published.
+        Please, note that messages are also published on this exchange if defined
+        using `createTask`.
 
-    This is useful for workers who doesn't want to constantly poll the queue
-    for new tasks. The queue will also be authority for task states and
-    claims. But using this exchange workers should be able to distribute work
-    efficiently and they would be able to reduce their polling interval
-    significantly without affecting general responsiveness.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-defined-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-pending-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-defined',
+            'name': 'taskDefined',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-defined-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskPending(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-pending', 'name': 'taskPending', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-pending-message.json#'}, *args, **kwargs)
+        """
+        Task Pending Messages
 
-    """
-    Task Running Messages
+        When a task becomes `pending` a message is posted to this exchange.
 
-    Whenever a task is claimed by a worker, a run is started on the worker,
-    and a message is posted on this exchange.
+        This is useful for workers who doesn't want to constantly poll the queue
+        for new tasks. The queue will also be authority for task states and
+        claims. But using this exchange workers should be able to distribute work
+        efficiently and they would be able to reduce their polling interval
+        significantly without affecting general responsiveness.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-running-message.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-pending-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-pending',
+            'name': 'taskPending',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-pending-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskRunning(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-running', 'name': 'taskRunning', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-running-message.json#'}, *args, **kwargs)
+        """
+        Task Running Messages
 
-    """
-    Artifact Creation Messages
+        Whenever a task is claimed by a worker, a run is started on the worker,
+        and a message is posted on this exchange.
 
-    Whenever the `createArtifact` end-point is called, the queue will create
-    a record of the artifact and post a message on this exchange. All of this
-    happens before the queue returns a signed URL for the caller to upload
-    the actual artifact with (pending on `storageType`).
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-running-message.json#``This exchange takes the following keys:
 
-    This means that the actual artifact is rarely available when this message
-    is posted. But it is not unreasonable to assume that the artifact will
-    will become available at some point later. Most signatures will expire in
-    30 minutes or so, forcing the uploader to call `createArtifact` with
-    the same payload again in-order to continue uploading the artifact.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    However, in most cases (especially for small artifacts) it's very
-    reasonable assume the artifact will be available within a few minutes.
-    This property means that this exchange is mostly useful for tools
-    monitoring task evaluation. One could also use it count number of
-    artifacts per task, or _index_ artifacts though in most cases it'll be
-    smarter to index artifacts after the task in question have completed
-    successfully.
+         * taskId: `taskId` for the task this message concerns (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#``This exchange takes the following keys:
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * schedulerId: `schedulerId` this task was created by. (required)
-
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-running',
+            'name': 'taskRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-running-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def artifactCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'artifact-created', 'name': 'artifactCreated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#'}, *args, **kwargs)
+        """
+        Artifact Creation Messages
 
-    """
-    Task Completed Messages
+        Whenever the `createArtifact` end-point is called, the queue will create
+        a record of the artifact and post a message on this exchange. All of this
+        happens before the queue returns a signed URL for the caller to upload
+        the actual artifact with (pending on `storageType`).
 
-    When a task is successfully completed by a worker a message is posted
-    this exchange.
-    This message is routed using the `runId`, `workerGroup` and `workerId`
-    that completed the task. But information about additional runs is also
-    available from the task status structure.
+        This means that the actual artifact is rarely available when this message
+        is posted. But it is not unreasonable to assume that the artifact will
+        will become available at some point later. Most signatures will expire in
+        30 minutes or so, forcing the uploader to call `createArtifact` with
+        the same payload again in-order to continue uploading the artifact.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-completed-message.json#``This exchange takes the following keys:
+        However, in most cases (especially for small artifacts) it's very
+        reasonable assume the artifact will be available within a few minutes.
+        This property means that this exchange is mostly useful for tools
+        monitoring task evaluation. One could also use it count number of
+        artifacts per task, or _index_ artifacts though in most cases it'll be
+        smarter to index artifacts after the task in question have completed
+        successfully.
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#``This exchange takes the following keys:
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * taskGroupId: `taskGroupId` this task was created in. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'artifact-created',
+            'name': 'artifactCreated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskCompleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-completed', 'name': 'taskCompleted', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-completed-message.json#'}, *args, **kwargs)
+        """
+        Task Completed Messages
 
-    """
-    Task Failed Messages
+        When a task is successfully completed by a worker a message is posted
+        this exchange.
+        This message is routed using the `runId`, `workerGroup` and `workerId`
+        that completed the task. But information about additional runs is also
+        available from the task status structure.
 
-    When a task ran, but failed to complete successfully a message is posted
-    to this exchange. This is same as worker ran task-specific code, but the
-    task specific code exited non-zero.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-completed-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-failed-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-completed',
+            'name': 'taskCompleted',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-completed-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskFailed(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-failed', 'name': 'taskFailed', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-failed-message.json#'}, *args, **kwargs)
+        """
+        Task Failed Messages
 
-    """
-    Task Exception Messages
+        When a task ran, but failed to complete successfully a message is posted
+        to this exchange. This is same as worker ran task-specific code, but the
+        task specific code exited non-zero.
 
-    Whenever Taskcluster fails to run a message is posted to this exchange.
-    This happens if the task isn't completed before its `deadlìne`,
-    all retries failed (i.e. workers stopped responding), the task was
-    canceled by another entity, or the task carried a malformed payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-failed-message.json#``This exchange takes the following keys:
 
-    The specific _reason_ is evident from that task status structure, refer
-    to the `reasonResolved` property for the last run.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-exception-message.json#``This exchange takes the following keys:
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * workerType: `workerType` this task must run on. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-failed',
+            'name': 'taskFailed',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-failed-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskException(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-exception', 'name': 'taskException', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-exception-message.json#'}, *args, **kwargs)
+        """
+        Task Exception Messages
 
-    """
-    Task Group Resolved Messages
+        Whenever Taskcluster fails to run a message is posted to this exchange.
+        This happens if the task isn't completed before its `deadlìne`,
+        all retries failed (i.e. workers stopped responding), the task was
+        canceled by another entity, or the task carried a malformed payload.
 
-    A message is published on task-group-resolved whenever all submitted
-    tasks (whether scheduled or unscheduled) for a given task group have
-    been resolved, regardless of whether they resolved as successful or
-    not. A task group may be resolved multiple times, since new tasks may
-    be submitted against an already resolved task group.
+        The specific _reason_ is evident from that task status structure, refer
+        to the `reasonResolved` property for the last run.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-exception-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskGroupId: `taskGroupId` for the task-group this message concerns (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * schedulerId: `schedulerId` for the task-group this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+
+         * provisionerId: `provisionerId` this task is targeted at. (required)
+
+         * workerType: `workerType` this task must run on. (required)
+
+         * schedulerId: `schedulerId` this task was created by. (required)
+
+         * taskGroupId: `taskGroupId` this task was created in. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-exception',
+            'name': 'taskException',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-exception-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGroupResolved(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-group-resolved', 'name': 'taskGroupResolved', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` for the task-group this message concerns'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` for the task-group this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#'}, *args, **kwargs)
+        """
+        Task Group Resolved Messages
+
+        A message is published on task-group-resolved whenever all submitted
+        tasks (whether scheduled or unscheduled) for a given task group have
+        been resolved, regardless of whether they resolved as successful or
+        not. A task group may be resolved multiple times, since new tasks may
+        be submitted against an already resolved task group.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * taskGroupId: `taskGroupId` for the task-group this message concerns (required)
+
+         * schedulerId: `schedulerId` for the task-group this message concerns (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-group-resolved',
+            'name': 'taskGroupResolved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/scheduler.py
+++ b/taskcluster/async/scheduler.py
@@ -99,7 +99,7 @@ class Scheduler(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/scheduler/v1/task-graph.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
 
         This method is ``experimental``
         """
@@ -126,7 +126,7 @@ class Scheduler(AsyncBaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/scheduler/v1/extend-task-graph-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
 
         This method is ``experimental``
         """
@@ -143,7 +143,7 @@ class Scheduler(AsyncBaseClient):
 
         **Note**, that `finished` implies successfully completion.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json``
 
         This method is ``experimental``
         """
@@ -161,7 +161,7 @@ class Scheduler(AsyncBaseClient):
         If you want more detailed information use the `inspectTaskGraph`
         end-point instead.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json``
 
         This method is ``experimental``
         """
@@ -185,7 +185,7 @@ class Scheduler(AsyncBaseClient):
         as we do not promise it will remain fully backward compatible in
         the future.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json``
 
         This method is ``experimental``
         """
@@ -209,7 +209,7 @@ class Scheduler(AsyncBaseClient):
         as we do not promise it will remain fully backward compatible in
         the future.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json``
 
         This method is ``experimental``
         """
@@ -230,49 +230,63 @@ class Scheduler(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "createTaskGraph": {           'args': ['taskGraphId'],
+        "createTaskGraph": {
+            'args': ['taskGraphId'],
             'input': 'http://schemas.taskcluster.net/scheduler/v1/task-graph.json#',
             'method': 'put',
             'name': 'createTaskGraph',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#',
             'route': '/task-graph/<taskGraphId>',
-            'stability': 'experimental'},
-        "extendTaskGraph": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "extendTaskGraph": {
+            'args': ['taskGraphId'],
             'input': 'http://schemas.taskcluster.net/scheduler/v1/extend-task-graph-request.json#',
             'method': 'post',
             'name': 'extendTaskGraph',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#',
             'route': '/task-graph/<taskGraphId>/extend',
-            'stability': 'experimental'},
-        "info": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "info": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'info',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json',
             'route': '/task-graph/<taskGraphId>/info',
-            'stability': 'experimental'},
-        "inspect": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "inspect": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'inspect',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json',
             'route': '/task-graph/<taskGraphId>/inspect',
-            'stability': 'experimental'},
-        "inspectTask": {           'args': ['taskGraphId', 'taskId'],
+            'stability': 'experimental',
+        },
+        "inspectTask": {
+            'args': ['taskGraphId', 'taskId'],
             'method': 'get',
             'name': 'inspectTask',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json',
             'route': '/task-graph/<taskGraphId>/inspect/<taskId>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'experimental'},
-        "status": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "status": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'status',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json',
             'route': '/task-graph/<taskGraphId>/status',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/async/schedulerevents.py
+++ b/taskcluster/async/schedulerevents.py
@@ -44,143 +44,335 @@ class SchedulerEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-scheduler/v1/"
     }
 
-    """
-    Task-Graph Running Message
-
-    When a task-graph is submitted it immediately starts running and a
-    message is posted on this exchange to indicate that a task-graph have
-    been submitted.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * taskId: Always takes the value `_`
-
-     * runId: Always takes the value `_`
-
-     * workerGroup: Always takes the value `_`
-
-     * workerId: Always takes the value `_`
-
-     * provisionerId: Always takes the value `_`
-
-     * workerType: Always takes the value `_`
-
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
-
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def taskGraphRunning(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-running', 'name': 'taskGraphRunning', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Running Message
 
-    """
-    Task-Graph Extended Message
+        When a task-graph is submitted it immediately starts running and a
+        message is posted on this exchange to indicate that a task-graph have
+        been submitted.
 
-    When a task-graph is extended, that is additional tasks is added to the
-    task-graph, a message is posted on this exchange. This is useful if you
-    are monitoring a task-graph and what to track states of the individual
-    tasks in the task-graph.
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: Always takes the value `_`
 
-     * taskId: Always takes the value `_`
+         * runId: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * workerType: Always takes the value `_`
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-graph-running',
+            'name': 'taskGraphRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphExtended(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-extended', 'name': 'taskGraphExtended', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Extended Message
 
-    """
-    Task-Graph Blocked Message
+        When a task-graph is extended, that is additional tasks is added to the
+        task-graph, a message is posted on this exchange. This is useful if you
+        are monitoring a task-graph and what to track states of the individual
+        tasks in the task-graph.
 
-    When a task is completed unsuccessfully and all reruns have been
-    attempted, the task-graph will not complete successfully and it's
-    declared to be _blocked_, by some task that consistently completes
-    unsuccessfully.
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#``This exchange takes the following keys:
 
-    When a task-graph becomes blocked a messages is posted to this exchange.
-    The message features the `taskId` of the task that caused the task-graph
-    to become blocked.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#``This exchange takes the following keys:
+         * taskId: Always takes the value `_`
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * runId: Always takes the value `_`
 
-     * taskId: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * workerType: Always takes the value `_`
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-graph-extended',
+            'name': 'taskGraphExtended',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphBlocked(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-blocked', 'name': 'taskGraphBlocked', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Blocked Message
 
-    """
-    Task-Graph Finished Message
+        When a task is completed unsuccessfully and all reruns have been
+        attempted, the task-graph will not complete successfully and it's
+        declared to be _blocked_, by some task that consistently completes
+        unsuccessfully.
 
-    When all tasks of a task-graph have completed successfully, the
-    task-graph is declared to be finished, and a message is posted to this
-    exchange.
+        When a task-graph becomes blocked a messages is posted to this exchange.
+        The message features the `taskId` of the task that caused the task-graph
+        to become blocked.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskId: Always takes the value `_`
+         * taskId: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * runId: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * workerType: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-graph-blocked',
+            'name': 'taskGraphBlocked',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphFinished(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-finished', 'name': 'taskGraphFinished', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Finished Message
+
+        When all tasks of a task-graph have completed successfully, the
+        task-graph is declared to be finished, and a message is posted to this
+        exchange.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * taskId: Always takes the value `_`
+
+         * runId: Always takes the value `_`
+
+         * workerGroup: Always takes the value `_`
+
+         * workerId: Always takes the value `_`
+
+         * provisionerId: Always takes the value `_`
+
+         * workerType: Always takes the value `_`
+
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-graph-finished',
+            'name': 'taskGraphFinished',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/async/secrets.py
+++ b/taskcluster/async/secrets.py
@@ -60,7 +60,7 @@ class Secrets(AsyncBaseClient):
         scope necessary to get the secret, the call will fail with a 403 code
         regardless of whether the secret exists.
 
-        This method takes output: ``http://schemas.taskcluster.net/secrets/v1/secret.json#``
+        This method gives output: ``http://schemas.taskcluster.net/secrets/v1/secret.json#``
 
         This method is ``stable``
         """
@@ -75,7 +75,7 @@ class Secrets(AsyncBaseClient):
         other words, secret name `<X>` will only be returned if a) a secret
         with name `<X>` exists, and b) you posses the scope `secrets:get:<X>`.
 
-        This method takes output: ``http://schemas.taskcluster.net/secrets/v1/secret-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/secrets/v1/secret-list.json#``
 
         This method is ``stable``
         """
@@ -95,34 +95,44 @@ class Secrets(AsyncBaseClient):
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "get": {           'args': ['name'],
+        "get": {
+            'args': ['name'],
             'method': 'get',
             'name': 'get',
             'output': 'http://schemas.taskcluster.net/secrets/v1/secret.json#',
             'route': '/secret/<name>',
-            'stability': 'stable'},
-        "list": {           'args': [],
+            'stability': 'stable',
+        },
+        "list": {
+            'args': [],
             'method': 'get',
             'name': 'list',
             'output': 'http://schemas.taskcluster.net/secrets/v1/secret-list.json#',
             'route': '/secrets',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "remove": {           'args': ['name'],
+            'stability': 'stable',
+        },
+        "remove": {
+            'args': ['name'],
             'method': 'delete',
             'name': 'remove',
             'route': '/secret/<name>',
-            'stability': 'stable'},
-        "set": {           'args': ['name'],
+            'stability': 'stable',
+        },
+        "set": {
+            'args': ['name'],
             'input': 'http://schemas.taskcluster.net/secrets/v1/secret.json#',
             'method': 'put',
             'name': 'set',
             'route': '/secret/<name>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/async/treeherderevents.py
+++ b/taskcluster/async/treeherderevents.py
@@ -26,23 +26,42 @@ class TreeherderEvents(AsyncBaseClient):
         "exchangePrefix": "exchange/taskcluster-treeherder/v1/"
     }
 
-    """
-    Job Messages
-
-    When a task run is scheduled or resolved, a message is posted to
-    this exchange in a Treeherder consumable format.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
-
-     * destination: destination (required)
-
-     * project: project (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def jobs(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'jobs', 'name': 'jobs', 'routingKey': [{'multipleWords': False, 'name': 'destination', 'required': True, 'summary': 'destination'}, {'multipleWords': False, 'name': 'project', 'required': True, 'summary': 'project'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#'}, *args, **kwargs)
+        """
+        Job Messages
+
+        When a task run is scheduled or resolved, a message is posted to
+        this exchange in a Treeherder consumable format.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
+
+         * destination: destination (required)
+
+         * project: project (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'jobs',
+            'name': 'jobs',
+            'routingKey': [
+                {
+                    'multipleWords': False,
+                    'name': 'destination',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'project',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/auth.py
+++ b/taskcluster/auth.py
@@ -65,7 +65,7 @@ class Auth(BaseClient):
         Get a list of all clients.  With `prefix`, only clients for which
         it is a prefix of the clientId are returned.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/list-clients-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/list-clients-response.json#``
 
         This method is ``stable``
         """
@@ -78,7 +78,7 @@ class Auth(BaseClient):
 
         Get information about a single client.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -104,7 +104,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-client-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
 
         This method is ``stable``
         """
@@ -122,7 +122,7 @@ class Auth(BaseClient):
         There is no way to retrieve an existing `accessToken`, so if you loose it
         you must reset the accessToken to acquire it again.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/create-client-response.json#``
 
         This method is ``stable``
         """
@@ -141,7 +141,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-client-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -158,7 +158,7 @@ class Auth(BaseClient):
         This is typically used by identity providers to re-enable clients that
         had been disabled when the corresponding identity's scopes changed.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -174,7 +174,7 @@ class Auth(BaseClient):
         This is typically used by identity providers to disable clients when the
         corresponding identity's scopes no longer satisfy the client's scopes.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-client-response.json#``
 
         This method is ``stable``
         """
@@ -200,7 +200,7 @@ class Auth(BaseClient):
         Get a list of all roles, each role object also includes the list of
         scopes it expands to.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/list-roles-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/list-roles-response.json#``
 
         This method is ``stable``
         """
@@ -214,7 +214,7 @@ class Auth(BaseClient):
         Get information about a single role, including the set of scopes that the
         role expands to.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -234,7 +234,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-role-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -252,7 +252,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/create-role-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/get-role-response.json#``
 
         This method is ``stable``
         """
@@ -280,7 +280,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
         This method is ``stable``
         """
@@ -295,7 +295,7 @@ class Auth(BaseClient):
         of scopes and scope restrictions (temporary credentials, assumeScopes, client scopes,
         and roles).
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/scopeset.json#``
 
         This method is ``stable``
         """
@@ -372,7 +372,7 @@ class Auth(BaseClient):
         For details on the format returned by EC2 metadata service see:
         [EC2 User Guide](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials).
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#``
 
         This method is ``stable``
         """
@@ -385,7 +385,7 @@ class Auth(BaseClient):
 
         Retrieve a list of all Azure accounts managed by Taskcluster Auth.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#``
 
         This method is ``stable``
         """
@@ -398,7 +398,7 @@ class Auth(BaseClient):
 
         Retrieve a list of all tables in an account.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#``
 
         This method is ``stable``
         """
@@ -416,7 +416,7 @@ class Auth(BaseClient):
         which type of credentials are returned.  If level is read-write, it will create the
         table if it doesn't already exist.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#``
 
         This method is ``stable``
         """
@@ -434,7 +434,7 @@ class Auth(BaseClient):
         which type of credentials are returned.  If level is read-write, it will create the
         container if it doesn't already exist.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#``
 
         This method is ``stable``
         """
@@ -453,7 +453,7 @@ class Auth(BaseClient):
         initial team configured for this component. Contact a Sentry admin
         to have the project transferred to a team you have access to if needed
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#``
 
         This method is ``stable``
         """
@@ -468,7 +468,7 @@ class Auth(BaseClient):
 
         The token is valid for 24 hours, clients should refresh after expiration.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#``
 
         This method is ``stable``
         """
@@ -482,7 +482,7 @@ class Auth(BaseClient):
         Get temporary `token` and `id` for connecting to webhooktunnel
         The token is valid for 96 hours, clients should refresh after expiration.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#``
 
         This method is ``stable``
         """
@@ -502,7 +502,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#``
 
         This method is ``stable``
         """
@@ -527,7 +527,7 @@ class Auth(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
 
         This method is ``stable``
         """
@@ -554,7 +554,7 @@ class Auth(BaseClient):
         This method may later be extended to allow specification of client and
         required scopes via query arguments.
 
-        This method takes output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#``
 
         This method is ``stable``
         """
@@ -574,175 +574,229 @@ class Auth(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "authenticateHawk": {           'args': [],
+        "authenticateHawk": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/authenticate-hawk-request.json#',
             'method': 'post',
             'name': 'authenticateHawk',
             'output': 'http://schemas.taskcluster.net/auth/v1/authenticate-hawk-response.json#',
             'route': '/authenticate-hawk',
-            'stability': 'stable'},
-        "awsS3Credentials": {           'args': ['level', 'bucket', 'prefix'],
+            'stability': 'stable',
+        },
+        "awsS3Credentials": {
+            'args': ['level', 'bucket', 'prefix'],
             'method': 'get',
             'name': 'awsS3Credentials',
             'output': 'http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#',
             'query': ['format'],
             'route': '/aws/s3/<level>/<bucket>/<prefix>',
-            'stability': 'stable'},
-        "azureAccounts": {           'args': [],
+            'stability': 'stable',
+        },
+        "azureAccounts": {
+            'args': [],
             'method': 'get',
             'name': 'azureAccounts',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-account-list-response.json#',
             'route': '/azure/accounts',
-            'stability': 'stable'},
-        "azureBlobSAS": {           'args': ['account', 'container', 'level'],
+            'stability': 'stable',
+        },
+        "azureBlobSAS": {
+            'args': ['account', 'container', 'level'],
             'method': 'get',
             'name': 'azureBlobSAS',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-blob-response.json#',
             'route': '/azure/<account>/containers/<container>/<level>',
-            'stability': 'stable'},
-        "azureTableSAS": {           'args': ['account', 'table', 'level'],
+            'stability': 'stable',
+        },
+        "azureTableSAS": {
+            'args': ['account', 'table', 'level'],
             'method': 'get',
             'name': 'azureTableSAS',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-table-access-response.json#',
             'route': '/azure/<account>/table/<table>/<level>',
-            'stability': 'stable'},
-        "azureTables": {           'args': ['account'],
+            'stability': 'stable',
+        },
+        "azureTables": {
+            'args': ['account'],
             'method': 'get',
             'name': 'azureTables',
             'output': 'http://schemas.taskcluster.net/auth/v1/azure-table-list-response.json#',
             'query': ['continuationToken'],
             'route': '/azure/<account>/tables',
-            'stability': 'stable'},
-        "client": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "client": {
+            'args': ['clientId'],
             'method': 'get',
             'name': 'client',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "createClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "createClient": {
+            'args': ['clientId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-client-request.json#',
             'method': 'put',
             'name': 'createClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/create-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "createRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "createRole": {
+            'args': ['roleId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-role-request.json#',
             'method': 'put',
             'name': 'createRole',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "currentScopes": {           'args': [],
+            'stability': 'stable',
+        },
+        "currentScopes": {
+            'args': [],
             'method': 'get',
             'name': 'currentScopes',
             'output': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'route': '/scopes/current',
-            'stability': 'stable'},
-        "deleteClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "deleteClient": {
+            'args': ['clientId'],
             'method': 'delete',
             'name': 'deleteClient',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "deleteRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "deleteRole": {
+            'args': ['roleId'],
             'method': 'delete',
             'name': 'deleteRole',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "disableClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "disableClient": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'disableClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>/disable',
-            'stability': 'stable'},
-        "enableClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "enableClient": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'enableClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>/enable',
-            'stability': 'stable'},
-        "expandScopes": {           'args': [],
+            'stability': 'stable',
+        },
+        "expandScopes": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'method': 'get',
             'name': 'expandScopes',
             'output': 'http://schemas.taskcluster.net/auth/v1/scopeset.json#',
             'route': '/scopes/expand',
-            'stability': 'stable'},
-        "listClients": {           'args': [],
+            'stability': 'stable',
+        },
+        "listClients": {
+            'args': [],
             'method': 'get',
             'name': 'listClients',
             'output': 'http://schemas.taskcluster.net/auth/v1/list-clients-response.json#',
             'query': ['prefix'],
             'route': '/clients/',
-            'stability': 'stable'},
-        "listRoles": {           'args': [],
+            'stability': 'stable',
+        },
+        "listRoles": {
+            'args': [],
             'method': 'get',
             'name': 'listRoles',
             'output': 'http://schemas.taskcluster.net/auth/v1/list-roles-response.json#',
             'route': '/roles/',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "resetAccessToken": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "resetAccessToken": {
+            'args': ['clientId'],
             'method': 'post',
             'name': 'resetAccessToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/create-client-response.json#',
             'route': '/clients/<clientId>/reset',
-            'stability': 'stable'},
-        "role": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "role": {
+            'args': ['roleId'],
             'method': 'get',
             'name': 'role',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "sentryDSN": {           'args': ['project'],
+            'stability': 'stable',
+        },
+        "sentryDSN": {
+            'args': ['project'],
             'method': 'get',
             'name': 'sentryDSN',
             'output': 'http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#',
             'route': '/sentry/<project>/dsn',
-            'stability': 'stable'},
-        "statsumToken": {           'args': ['project'],
+            'stability': 'stable',
+        },
+        "statsumToken": {
+            'args': ['project'],
             'method': 'get',
             'name': 'statsumToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#',
             'route': '/statsum/<project>/token',
-            'stability': 'stable'},
-        "testAuthenticate": {           'args': [],
+            'stability': 'stable',
+        },
+        "testAuthenticate": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-request.json#',
             'method': 'post',
             'name': 'testAuthenticate',
             'output': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#',
             'route': '/test-authenticate',
-            'stability': 'stable'},
-        "testAuthenticateGet": {           'args': [],
+            'stability': 'stable',
+        },
+        "testAuthenticateGet": {
+            'args': [],
             'method': 'get',
             'name': 'testAuthenticateGet',
             'output': 'http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#',
             'route': '/test-authenticate-get/',
-            'stability': 'stable'},
-        "updateClient": {           'args': ['clientId'],
+            'stability': 'stable',
+        },
+        "updateClient": {
+            'args': ['clientId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-client-request.json#',
             'method': 'post',
             'name': 'updateClient',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-client-response.json#',
             'route': '/clients/<clientId>',
-            'stability': 'stable'},
-        "updateRole": {           'args': ['roleId'],
+            'stability': 'stable',
+        },
+        "updateRole": {
+            'args': ['roleId'],
             'input': 'http://schemas.taskcluster.net/auth/v1/create-role-request.json#',
             'method': 'post',
             'name': 'updateRole',
             'output': 'http://schemas.taskcluster.net/auth/v1/get-role-response.json#',
             'route': '/roles/<roleId>',
-            'stability': 'stable'},
-        "webhooktunnelToken": {           'args': [],
+            'stability': 'stable',
+        },
+        "webhooktunnelToken": {
+            'args': [],
             'method': 'get',
             'name': 'webhooktunnelToken',
             'output': 'http://schemas.taskcluster.net/auth/v1/webhooktunnel-token-response.json#',
             'route': '/webhooktunnel',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/authevents.py
+++ b/taskcluster/authevents.py
@@ -27,83 +27,149 @@ class AuthEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-auth/v1/"
     }
 
-    """
-    Client Created Messages
-
-    Message that a new client has been created.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def clientCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-created', 'name': 'clientCreated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Created Messages
 
-    """
-    Client Updated Messages
+        Message that a new client has been created.
 
-    Message that a new client has been updated.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-created',
+            'name': 'clientCreated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def clientUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-updated', 'name': 'clientUpdated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Updated Messages
 
-    """
-    Client Deleted Messages
+        Message that a new client has been updated.
 
-    Message that a new client has been deleted.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-updated',
+            'name': 'clientUpdated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def clientDeleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'client-deleted', 'name': 'clientDeleted', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#'}, *args, **kwargs)
+        """
+        Client Deleted Messages
 
-    """
-    Role Created Messages
+        Message that a new client has been deleted.
 
-    Message that a new role has been created.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/client-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'client-deleted',
+            'name': 'clientDeleted',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/client-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-created', 'name': 'roleCreated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Created Messages
 
-    """
-    Role Updated Messages
+        Message that a new role has been created.
 
-    Message that a new role has been updated.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'role-created',
+            'name': 'roleCreated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-updated', 'name': 'roleUpdated', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Updated Messages
 
-    """
-    Role Deleted Messages
+        Message that a new role has been updated.
 
-    Message that a new role has been deleted.
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'role-updated',
+            'name': 'roleUpdated',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def roleDeleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'role-deleted', 'name': 'roleDeleted', 'routingKey': [{'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#'}, *args, **kwargs)
+        """
+        Role Deleted Messages
+
+        Message that a new role has been deleted.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/auth/v1/role-message.json#``This exchange takes the following keys:
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'role-deleted',
+            'name': 'roleDeleted',
+            'routingKey': [
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/auth/v1/role-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/awsprovisioner.py
+++ b/taskcluster/awsprovisioner.py
@@ -56,7 +56,7 @@ class AwsProvisioner(BaseClient):
         there may be running EC2 instances for deleted worker types that are not
         included here.  The list is unordered.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#``
 
         This method is ``stable``
         """
@@ -93,7 +93,7 @@ class AwsProvisioner(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -118,7 +118,7 @@ class AwsProvisioner(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -135,7 +135,7 @@ class AwsProvisioner(BaseClient):
         If the worker type definition has not been changed, the date
         should be identical as it is the same stored value.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#``
 
         This method is ``stable``
         """
@@ -152,7 +152,7 @@ class AwsProvisioner(BaseClient):
         use the results of this method to submit date to the update
         method.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#``
 
         This method is ``stable``
         """
@@ -188,7 +188,7 @@ class AwsProvisioner(BaseClient):
         not include worker types which are left overs from a deleted worker
         type definition but are still running in AWS.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#``
 
         This method is ``stable``
         """
@@ -225,7 +225,7 @@ class AwsProvisioner(BaseClient):
         or else the secrets will be visible to any process which can access the
         user data associated with the instance.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#``
 
         This method is ``stable``
         """
@@ -273,7 +273,7 @@ class AwsProvisioner(BaseClient):
 
         **This API end-point is experimental and may be subject to change without warning.**
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#``
 
         This method is ``experimental``
         """
@@ -306,7 +306,7 @@ class AwsProvisioner(BaseClient):
 
         **Warning** this api end-point is **not stable**.
 
-        This method takes output: ``http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#``
 
         This method is ``experimental``
         """
@@ -326,93 +326,123 @@ class AwsProvisioner(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "backendStatus": {           'args': [],
+        "backendStatus": {
+            'args': [],
             'method': 'get',
             'name': 'backendStatus',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#',
             'route': '/backend-status',
-            'stability': 'experimental'},
-        "createSecret": {           'args': ['token'],
+            'stability': 'experimental',
+        },
+        "createSecret": {
+            'args': ['token'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-secret-request.json#',
             'method': 'put',
             'name': 'createSecret',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "createWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "createWorkerType": {
+            'args': ['workerType'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#',
             'method': 'put',
             'name': 'createWorkerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "getLaunchSpecs": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "getLaunchSpecs": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'getLaunchSpecs',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#',
             'route': '/worker-type/<workerType>/launch-specifications',
-            'stability': 'experimental'},
-        "getSecret": {           'args': ['token'],
+            'stability': 'experimental',
+        },
+        "getSecret": {
+            'args': ['token'],
             'method': 'get',
             'name': 'getSecret',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "instanceStarted": {           'args': ['instanceId', 'token'],
+            'stability': 'stable',
+        },
+        "instanceStarted": {
+            'args': ['instanceId', 'token'],
             'method': 'get',
             'name': 'instanceStarted',
             'route': '/instance-started/<instanceId>/<token>',
-            'stability': 'stable'},
-        "listWorkerTypeSummaries": {           'args': [],
+            'stability': 'stable',
+        },
+        "listWorkerTypeSummaries": {
+            'args': [],
             'method': 'get',
             'name': 'listWorkerTypeSummaries',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#',
             'route': '/list-worker-type-summaries',
-            'stability': 'stable'},
-        "listWorkerTypes": {           'args': [],
+            'stability': 'stable',
+        },
+        "listWorkerTypes": {
+            'args': [],
             'method': 'get',
             'name': 'listWorkerTypes',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#',
             'route': '/list-worker-types',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "removeSecret": {           'args': ['token'],
+            'stability': 'stable',
+        },
+        "removeSecret": {
+            'args': ['token'],
             'method': 'delete',
             'name': 'removeSecret',
             'route': '/secret/<token>',
-            'stability': 'stable'},
-        "removeWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "removeWorkerType": {
+            'args': ['workerType'],
             'method': 'delete',
             'name': 'removeWorkerType',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "state": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "state": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'state',
             'route': '/state/<workerType>',
-            'stability': 'stable'},
-        "updateWorkerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "updateWorkerType": {
+            'args': ['workerType'],
             'input': 'http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#',
             'method': 'post',
             'name': 'updateWorkerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>/update',
-            'stability': 'stable'},
-        "workerType": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "workerType": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'workerType',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#',
             'route': '/worker-type/<workerType>',
-            'stability': 'stable'},
-        "workerTypeLastModified": {           'args': ['workerType'],
+            'stability': 'stable',
+        },
+        "workerTypeLastModified": {
+            'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeLastModified',
             'output': 'http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#',
             'route': '/worker-type-last-modified/<workerType>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/awsprovisionerevents.py
+++ b/taskcluster/awsprovisionerevents.py
@@ -20,59 +20,119 @@ class AwsProvisionerEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/"
     }
 
-    """
-    WorkerType Created Message
-
-    When a new `workerType` is created a message will be published to this
-    exchange.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * workerType: WorkerType that this message concerns. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def workerTypeCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-created', 'name': 'workerTypeCreated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Created Message
 
-    """
-    WorkerType Updated Message
+        When a new `workerType` is created a message will be published to this
+        exchange.
 
-    When a `workerType` is updated a message will be published to this
-    exchange.
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerType: WorkerType that this message concerns. (required)
 
-     * workerType: WorkerType that this message concerns. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'worker-type-created',
+            'name': 'workerTypeCreated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def workerTypeUpdated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-updated', 'name': 'workerTypeUpdated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Updated Message
 
-    """
-    WorkerType Removed Message
+        When a `workerType` is updated a message will be published to this
+        exchange.
 
-    When a `workerType` is removed a message will be published to this
-    exchange.
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerType: WorkerType that this message concerns. (required)
 
-     * workerType: WorkerType that this message concerns. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'worker-type-updated',
+            'name': 'workerTypeUpdated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def workerTypeRemoved(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'worker-type-removed', 'name': 'workerTypeRemoved', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': 'WorkerType that this message concerns.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#'}, *args, **kwargs)
+        """
+        WorkerType Removed Message
+
+        When a `workerType` is removed a message will be published to this
+        exchange.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * workerType: WorkerType that this message concerns. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-type-removed',
+            'name': 'workerTypeRemoved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/aws-provisioner/v1/worker-type-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -266,15 +266,13 @@ class BaseClient(object):
             return response
 
     def _processArgs(self, entry, *_args, **_kwargs):
-        """ Figure out, given an entry, positional and keyword arguments, what
+        """ Given an entry, positional and keyword arguments, figure out what
         the query-string options, payload and api arguments are.
         """
 
         # We need the args to be a list so we can mutate them
         args = list(_args)
         kwargs = copy.deepcopy(_kwargs)
-        log.debug(args)
-        log.debug(kwargs)
 
         reqArgs = entry['args']
         routeParams = {}

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -13,6 +13,7 @@ import calendar
 import requests
 import time
 import six
+import warnings
 from six.moves import urllib
 
 import mohawk
@@ -305,6 +306,10 @@ class BaseClient(object):
                     payload = args.pop()
                 kwApiArgs = kwargs
                 log.debug('Using method(payload, k1=v1, k2=v2) calling convention')
+                warnings.warn(
+                    "The method(payload, k1=v1, k2=v2) calling convention will soon be deprecated",
+                    PendingDeprecationWarning
+                )
             else:
                 kwApiArgs = kwargs.get('params', {})
                 payload = kwargs.get('payload', None)

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -163,8 +163,10 @@ class BaseClient(object):
         if not entry:
             raise exceptions.TaskclusterFailure(
                 'Requested method "%s" not found in API Reference' % methodName)
-        apiArgs = self._processArgs(entry, *args, **kwargs)
-        route = self._subArgsInRoute(entry, apiArgs)
+        routeParams, _, query = self._processArgs(entry, *args, **kwargs)
+        route = self._subArgsInRoute(entry, routeParams)
+        if query:
+            route += '?' + urllib.parse.urlencode(query)
         return self.options['baseUrl'] + '/' + route
 
     def buildSignedUrl(self, methodName, *args, **kwargs):
@@ -219,12 +221,18 @@ class BaseClient(object):
             raise exceptions.TaskclusterFailure('Did not receive a bewit')
 
         u = urllib.parse.urlparse(requestUrl)
+
+        qs = u.query
+        if qs:
+            qs += '&'
+        qs += 'bewit=%s' % bewit
+
         return urllib.parse.urlunparse((
             u.scheme,
             u.netloc,
             u.path,
             u.params,
-            u.query + 'bewit=%s' % bewit,
+            qs,
             u.fragment,
         ))
 
@@ -232,49 +240,102 @@ class BaseClient(object):
         """ This function is used to dispatch calls to other functions
         for a given API Reference entry"""
 
-        payload = None
-        _args = list(args)
-        _kwargs = copy.deepcopy(kwargs)
-
-        if 'input' in entry:
-            if len(args) > 0:
-                payload = _args.pop()
-            else:
-                raise exceptions.TaskclusterFailure('Payload is required as last positional arg')
-        apiArgs = self._processArgs(entry, *_args, **_kwargs)
-        route = self._subArgsInRoute(entry, apiArgs)
+        routeParams, payload, query = self._processArgs(entry, *args, **kwargs)
+        route = self._subArgsInRoute(entry, routeParams)
+        if query:
+            route += '?' + urllib.parse.urlencode(query)
         log.debug('Route is: %s', route)
 
         return self._makeHttpRequest(entry['method'], route, payload)
 
-    def _processArgs(self, entry, *args, **kwargs):
-        """ Take the list of required arguments, positional arguments
-        and keyword arguments and return a dictionary which maps the
-        value of the given arguments to the required parameters.
-
-        Keyword arguments will overwrite positional arguments.
+    def _processArgs(self, entry, *_args, **_kwargs):
+        """ Figure out, given an entry, positional and keyword arguments, what
+        the query-string options, payload and api arguments are.
         """
 
+        # We need the args to be a list so we can mutate them
+        args = list(_args)
+        kwargs = copy.deepcopy(_kwargs)
+        log.debug(args)
+        log.debug(kwargs)
+
         reqArgs = entry['args']
-        data = {}
+        routeParams = {}
+
+        query = {}
+        payload = None
+        kwApiArgs = {}
+
+        # There are three formats for calling methods:
+        #   1. method(v1, v1, payload)
+        #   2. method(payload, k1=v1, k2=v2)
+        #   3. method(payload=payload, query=query, params={k1: v1, k2: v2})
+        if len(kwargs) == 0:
+            if 'input' in entry and len(args) == len(reqArgs) + 1:
+                payload = args.pop()
+            if len(args) != len(reqArgs):
+                log.debug(args)
+                log.debug(reqArgs)
+                raise exceptions.TaskclusterFailure('Incorrect number of positional arguments')
+            log.debug('Using method(v1, v2, payload) calling convention')
+        else:
+            # We're considering kwargs which are the api route parameters to be
+            # called 'flat' because they're top level keys.  We're special
+            # casing calls which have only api-arg kwargs and possibly a payload
+            # value and handling them directly.
+            isFlatKwargs = True
+            if len(kwargs) == len(reqArgs):
+                for arg in reqArgs:
+                    if not kwargs.get(arg, False):
+                        isFlatKwargs = False
+                        break
+                if 'input' in entry and len(args) != 1:
+                    isFlatKwargs = False
+                if not 'input' in entry and len(args) != 0:
+                    isFlatKwargs = False
+                else:
+                    pass # We're using payload=, query= and param=
+            else:
+                isFlatKwargs = False
+
+            # Now we're going to handle the two types of kwargs.  The first is
+            # 'flat' ones, which are where the api params
+            if isFlatKwargs:
+                if 'input' in entry:
+                    payload = args.pop()
+                kwApiArgs = kwargs
+                log.debug('Using method(payload, k1=v1, k2=v2) calling convention')
+            else:
+                kwApiArgs = kwargs.get('params', {})
+                payload = kwargs.get('payload', None)
+                query = kwargs.get('query', {})
+                log.debug('Using method(payload=payload, query=query, params={k1: v1, k2: v2}) calling convention')
+
+        if 'input' in entry and type(payload) == type(None):
+            raise exceptions.TaskclusterFailure('Payload is required')
 
         # These all need to be rendered down to a string, let's just check that
         # they are up front and fail fast
-        for arg in list(args) + [kwargs[x] for x in kwargs]:
+        for arg in args:
             if not isinstance(arg, six.string_types) and not isinstance(arg, int):
                 raise exceptions.TaskclusterFailure(
-                    'Arguments "%s" to %s is not a string or int' % (arg, entry['name']))
+                    'Positional arg "%s" to %s is not a string or int' % (arg, entry['name']))
 
-        if len(args) > 0 and len(kwargs) > 0:
+        for name, arg in six.iteritems(kwApiArgs):
+            if not isinstance(arg, six.string_types) and not isinstance(arg, int):
+                raise exceptions.TaskclusterFailure(
+                    'KW arg "%s: %s" to %s is not a string or int' % (name, arg, entry['name']))
+
+        if len(args) > 0 and len(kwApiArgs) > 0:
             raise exceptions.TaskclusterFailure('Specify either positional or key word arguments')
 
         # We know for sure that if we don't give enough arguments that the call
         # should fail.  We don't yet know if we should fail because of two many
         # arguments because we might be overwriting positional ones with kw ones
-        if len(reqArgs) > len(args) + len(kwargs):
+        if len(reqArgs) > len(args) + len(kwApiArgs):
             raise exceptions.TaskclusterFailure(
                 '%s takes %d args, only %d were given' % (
-                    entry['name'], len(reqArgs), len(args) + len(kwargs)))
+                    entry['name'], len(reqArgs), len(args) + len(kwApiArgs)))
 
         # We also need to error out when we have more positional args than required
         # because we'll need to go through the lists of provided and required args
@@ -287,31 +348,31 @@ class BaseClient(object):
         i = 0
         for arg in args:
             log.debug('Found a positional argument: %s', arg)
-            data[reqArgs[i]] = arg
+            routeParams[reqArgs[i]] = arg
             i += 1
 
-        log.debug('After processing positional arguments, we have: %s', data)
+        log.debug('After processing positional arguments, we have: %s', routeParams)
 
-        data.update(kwargs)
+        routeParams.update(kwApiArgs)
 
-        log.debug('After keyword arguments, we have: %s', data)
+        log.debug('After keyword arguments, we have: %s', routeParams)
 
-        if len(reqArgs) != len(data):
+        if len(reqArgs) != len(routeParams):
             errMsg = '%s takes %s args, %s given' % (
                 entry['name'],
                 ','.join(reqArgs),
-                data.keys())
+                routeParams.keys())
             log.error(errMsg)
             raise exceptions.TaskclusterFailure(errMsg)
 
         for reqArg in reqArgs:
-            if reqArg not in data:
+            if reqArg not in routeParams:
                 errMsg = '%s requires a "%s" argument which was not provided' % (
                     entry['name'], reqArg)
                 log.error(errMsg)
                 raise exceptions.TaskclusterFailure(errMsg)
 
-        return data
+        return routeParams, payload, query
 
     def _subArgsInRoute(self, entry, args):
         """ Given a route like "/task/<taskId>/artifacts" and a mapping like

--- a/taskcluster/github.py
+++ b/taskcluster/github.py
@@ -48,7 +48,7 @@ class Github(BaseClient):
         Taskcluster. Can be filtered on various git-specific
         fields.
 
-        This method takes output: ``http://schemas.taskcluster.net/github/v1/build-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/github/v1/build-list.json#``
 
         This method is ``experimental``
         """
@@ -74,7 +74,7 @@ class Github(BaseClient):
         Returns any repository metadata that is
         useful within Taskcluster related services.
 
-        This method takes output: ``http://schemas.taskcluster.net/github/v1/repository.json``
+        This method gives output: ``http://schemas.taskcluster.net/github/v1/repository.json``
 
         This method is ``experimental``
         """
@@ -138,55 +138,67 @@ class Github(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "badge": {           'args': ['owner', 'repo', 'branch'],
+        "badge": {
+            'args': ['owner', 'repo', 'branch'],
             'method': 'get',
             'name': 'badge',
             'route': '/repository/<owner>/<repo>/<branch>/badge.svg',
-            'stability': 'experimental'},
-        "builds": {           'args': [],
+            'stability': 'experimental',
+        },
+        "builds": {
+            'args': [],
             'method': 'get',
             'name': 'builds',
             'output': 'http://schemas.taskcluster.net/github/v1/build-list.json#',
-            'query': [           'continuationToken',
-                                 'limit',
-                                 'organization',
-                                 'repository',
-                                 'sha'],
+            'query': ['continuationToken', 'limit', 'organization', 'repository', 'sha'],
             'route': '/builds',
-            'stability': 'experimental'},
-        "createComment": {           'args': ['owner', 'repo', 'number'],
+            'stability': 'experimental',
+        },
+        "createComment": {
+            'args': ['owner', 'repo', 'number'],
             'input': 'http://schemas.taskcluster.net/github/v1/create-comment.json',
             'method': 'post',
             'name': 'createComment',
             'route': '/repository/<owner>/<repo>/issues/<number>/comments',
-            'stability': 'experimental'},
-        "createStatus": {           'args': ['owner', 'repo', 'sha'],
+            'stability': 'experimental',
+        },
+        "createStatus": {
+            'args': ['owner', 'repo', 'sha'],
             'input': 'http://schemas.taskcluster.net/github/v1/create-status.json',
             'method': 'post',
             'name': 'createStatus',
             'route': '/repository/<owner>/<repo>/statuses/<sha>',
-            'stability': 'experimental'},
-        "githubWebHookConsumer": {           'args': [],
+            'stability': 'experimental',
+        },
+        "githubWebHookConsumer": {
+            'args': [],
             'method': 'post',
             'name': 'githubWebHookConsumer',
             'route': '/github',
-            'stability': 'experimental'},
-        "latest": {           'args': ['owner', 'repo', 'branch'],
+            'stability': 'experimental',
+        },
+        "latest": {
+            'args': ['owner', 'repo', 'branch'],
             'method': 'get',
             'name': 'latest',
             'route': '/repository/<owner>/<repo>/<branch>/latest',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "repository": {           'args': ['owner', 'repo'],
+            'stability': 'stable',
+        },
+        "repository": {
+            'args': ['owner', 'repo'],
             'method': 'get',
             'name': 'repository',
             'output': 'http://schemas.taskcluster.net/github/v1/repository.json',
             'route': '/repository/<owner>/<repo>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/githubevents.py
+++ b/taskcluster/githubevents.py
@@ -25,64 +25,128 @@ class GithubEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-github/v1/"
     }
 
-    """
-    GitHub Pull Request Event
-
-    When a GitHub pull request event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
-
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-
-     * action: The GitHub `action` which triggered an event. See for possible values see the payload actions property. (required)
-    """
-
     def pullRequest(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'pull-request', 'name': 'pullRequest', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'action', 'required': True, 'summary': 'The GitHub `action` which triggered an event. See for possible values see the payload actions property.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#'}, *args, **kwargs)
+        """
+        GitHub Pull Request Event
 
-    """
-    GitHub push Event
+        When a GitHub pull request event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
 
-    When a GitHub push event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-push-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-    """
+         * action: The GitHub `action` which triggered an event. See for possible values see the payload actions property. (required)
+        """
+
+        ref = {
+            'exchange': 'pull-request',
+            'name': 'pullRequest',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'action',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-pull-request-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def push(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'push', 'name': 'push', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-push-message.json#'}, *args, **kwargs)
+        """
+        GitHub push Event
 
-    """
-    GitHub release Event
+        When a GitHub push event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
 
-    When a GitHub release event is posted it will be broadcast on this
-    exchange with the designated `organization` and `repository`
-    in the routing-key along with event specific metadata in the payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-push-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-release-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
 
-     * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+        """
 
-     * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
-    """
+        ref = {
+            'exchange': 'push',
+            'name': 'push',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-push-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def release(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'release', 'name': 'release', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.'}, {'multipleWords': False, 'name': 'organization', 'required': True, 'summary': 'The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}, {'multipleWords': False, 'name': 'repository', 'required': True, 'summary': 'The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped.'}], 'schema': 'http://schemas.taskcluster.net/github/v1/github-release-message.json#'}, *args, **kwargs)
+        """
+        GitHub release Event
+
+        When a GitHub release event is posted it will be broadcast on this
+        exchange with the designated `organization` and `repository`
+        in the routing-key along with event specific metadata in the payload.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/github/v1/github-release-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key. (required)
+
+         * organization: The GitHub `organization` which had an event. All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+
+         * repository: The GitHub `repository` which had an event.All periods have been replaced by % - such that foo.bar becomes foo%bar - and all other special characters aside from - and _ have been stripped. (required)
+        """
+
+        ref = {
+            'exchange': 'release',
+            'name': 'release',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'organization',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'repository',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/github/v1/github-release-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/hooks.py
+++ b/taskcluster/hooks.py
@@ -40,7 +40,7 @@ class Hooks(BaseClient):
 
         This endpoint will return a list of all hook groups with at least one hook.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json``
 
         This method is ``experimental``
         """
@@ -54,7 +54,7 @@ class Hooks(BaseClient):
         This endpoint will return a list of all the hook definitions within a
         given hook group.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json``
 
         This method is ``experimental``
         """
@@ -68,7 +68,7 @@ class Hooks(BaseClient):
         This endpoint will return the hook definition for the given `hookGroupId`
         and hookId.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -82,7 +82,7 @@ class Hooks(BaseClient):
         This endpoint will return the current status of the hook.  This represents a
         snapshot in time and may vary from one call to the next.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-status.json``
 
         This method is ``experimental``
         """
@@ -96,7 +96,7 @@ class Hooks(BaseClient):
         This endpoint will return the schedule and next scheduled creation time
         for the given hook.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-schedule.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-schedule.json``
 
         This method is ``deprecated``
         """
@@ -116,7 +116,7 @@ class Hooks(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/create-hook-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -132,7 +132,7 @@ class Hooks(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/create-hook-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/hook-definition.json``
 
         This method is ``experimental``
         """
@@ -158,7 +158,7 @@ class Hooks(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/trigger-payload.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
 
         This method is ``experimental``
         """
@@ -172,7 +172,7 @@ class Hooks(BaseClient):
         Retrieve a unique secret token for triggering the specified hook. This
         token can be deactivated with `resetTriggerToken`.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
 
         This method is ``experimental``
         """
@@ -186,7 +186,7 @@ class Hooks(BaseClient):
         Reset the token for triggering a given hook. This invalidates token that
         may have been issued via getTriggerToken with a new token.
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json``
 
         This method is ``experimental``
         """
@@ -201,7 +201,7 @@ class Hooks(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/hooks/v1/trigger-payload.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
+        This method gives output: ``http://schemas.taskcluster.net/hooks/v1/task-status.json``
 
         This method is ``experimental``
         """
@@ -221,86 +221,112 @@ class Hooks(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "createHook": {           'args': ['hookGroupId', 'hookId'],
+        "createHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/create-hook-request.json',
             'method': 'put',
             'name': 'createHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "getHookSchedule": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "getHookSchedule": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getHookSchedule',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-schedule.json',
             'route': '/hooks/<hookGroupId>/<hookId>/schedule',
-            'stability': 'deprecated'},
-        "getHookStatus": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'deprecated',
+        },
+        "getHookStatus": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getHookStatus',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/status',
-            'stability': 'experimental'},
-        "getTriggerToken": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "getTriggerToken": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'getTriggerToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json',
             'route': '/hooks/<hookGroupId>/<hookId>/token',
-            'stability': 'experimental'},
-        "hook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "hook": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'get',
             'name': 'hook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "listHookGroups": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listHookGroups": {
+            'args': [],
             'method': 'get',
             'name': 'listHookGroups',
             'output': 'http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json',
             'route': '/hooks',
-            'stability': 'experimental'},
-        "listHooks": {           'args': ['hookGroupId'],
+            'stability': 'experimental',
+        },
+        "listHooks": {
+            'args': ['hookGroupId'],
             'method': 'get',
             'name': 'listHooks',
             'output': 'http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json',
             'route': '/hooks/<hookGroupId>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "removeHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'stable',
+        },
+        "removeHook": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'delete',
             'name': 'removeHook',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
-        "resetTriggerToken": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "resetTriggerToken": {
+            'args': ['hookGroupId', 'hookId'],
             'method': 'post',
             'name': 'resetTriggerToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/trigger-token-response.json',
             'route': '/hooks/<hookGroupId>/<hookId>/token',
-            'stability': 'experimental'},
-        "triggerHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "triggerHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/trigger-payload.json',
             'method': 'post',
             'name': 'triggerHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/task-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/trigger',
-            'stability': 'experimental'},
-        "triggerHookWithToken": {           'args': ['hookGroupId', 'hookId', 'token'],
+            'stability': 'experimental',
+        },
+        "triggerHookWithToken": {
+            'args': ['hookGroupId', 'hookId', 'token'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/trigger-payload.json',
             'method': 'post',
             'name': 'triggerHookWithToken',
             'output': 'http://schemas.taskcluster.net/hooks/v1/task-status.json',
             'route': '/hooks/<hookGroupId>/<hookId>/trigger/<token>',
-            'stability': 'experimental'},
-        "updateHook": {           'args': ['hookGroupId', 'hookId'],
+            'stability': 'experimental',
+        },
+        "updateHook": {
+            'args': ['hookGroupId', 'hookId'],
             'input': 'http://schemas.taskcluster.net/hooks/v1/create-hook-request.json',
             'method': 'post',
             'name': 'updateHook',
             'output': 'http://schemas.taskcluster.net/hooks/v1/hook-definition.json',
             'route': '/hooks/<hookGroupId>/<hookId>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/index.py
+++ b/taskcluster/index.py
@@ -118,7 +118,7 @@ class Index(BaseClient):
         Find a task by index path, returning the highest-rank task with that path. If no
         task exists for the given path, this API end-point will respond with a 404 status.
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
 
         This method is ``stable``
         """
@@ -139,7 +139,7 @@ class Index(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/list-namespaces-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#``
 
         This method is ``stable``
         """
@@ -163,7 +163,7 @@ class Index(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/list-tasks-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/list-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/list-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -182,7 +182,7 @@ class Index(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/index/v1/insert-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/index/v1/indexed-task-response.json#``
 
         This method is ``stable``
         """
@@ -226,43 +226,55 @@ class Index(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "findArtifactFromTask": {           'args': ['indexPath', 'name'],
+        "findArtifactFromTask": {
+            'args': ['indexPath', 'name'],
             'method': 'get',
             'name': 'findArtifactFromTask',
             'route': '/task/<indexPath>/artifacts/<name>',
-            'stability': 'stable'},
-        "findTask": {           'args': ['indexPath'],
+            'stability': 'stable',
+        },
+        "findTask": {
+            'args': ['indexPath'],
             'method': 'get',
             'name': 'findTask',
             'output': 'http://schemas.taskcluster.net/index/v1/indexed-task-response.json#',
             'route': '/task/<indexPath>',
-            'stability': 'stable'},
-        "insertTask": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "insertTask": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/insert-task-request.json#',
             'method': 'put',
             'name': 'insertTask',
             'output': 'http://schemas.taskcluster.net/index/v1/indexed-task-response.json#',
             'route': '/task/<namespace>',
-            'stability': 'stable'},
-        "listNamespaces": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "listNamespaces": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/list-namespaces-request.json#',
             'method': 'post',
             'name': 'listNamespaces',
             'output': 'http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#',
             'route': '/namespaces/<namespace>',
-            'stability': 'stable'},
-        "listTasks": {           'args': ['namespace'],
+            'stability': 'stable',
+        },
+        "listTasks": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/index/v1/list-tasks-request.json#',
             'method': 'post',
             'name': 'listTasks',
             'output': 'http://schemas.taskcluster.net/index/v1/list-tasks-response.json#',
             'route': '/tasks/<namespace>',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/login.py
+++ b/taskcluster/login.py
@@ -47,7 +47,7 @@ class Login(BaseClient):
         monitor this expiration and refresh the credentials if necessary, by calling
         this endpoint again, if they have expired.
 
-        This method takes output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
 
         This method is ``experimental``
         """
@@ -67,17 +67,21 @@ class Login(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "oidcCredentials": {           'args': ['provider'],
+        "oidcCredentials": {
+            'args': ['provider'],
             'method': 'get',
             'name': 'oidcCredentials',
             'output': 'http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json',
             'route': '/oidc-credentials/<provider>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/notify.py
+++ b/taskcluster/notify.py
@@ -87,29 +87,37 @@ class Notify(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "email": {           'args': [],
+        "email": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/email-request.json',
             'method': 'post',
             'name': 'email',
             'route': '/email',
-            'stability': 'experimental'},
-        "irc": {           'args': [],
+            'stability': 'experimental',
+        },
+        "irc": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/irc-request.json',
             'method': 'post',
             'name': 'irc',
             'route': '/irc',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "pulse": {           'args': [],
+            'stability': 'stable',
+        },
+        "pulse": {
+            'args': [],
             'input': 'http://schemas.taskcluster.net/notify/v1/pulse-request.json',
             'method': 'post',
             'name': 'pulse',
             'route': '/pulse',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/pulse.py
+++ b/taskcluster/pulse.py
@@ -31,7 +31,7 @@ class Pulse(BaseClient):
 
         Get an overview of the Rabbit cluster.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
 
         This method is ``experimental``
         """
@@ -48,7 +48,7 @@ class Pulse(BaseClient):
         `continuationToken` will be returned, which can be given in the next
         request. For the initial request, do not provide continuation.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
 
         This method is ``experimental``
         """
@@ -62,7 +62,7 @@ class Pulse(BaseClient):
         Get public information about a single namespace. This is the same information
         as returned by `listNamespaces`.
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
 
         This method is ``experimental``
         """
@@ -84,7 +84,7 @@ class Pulse(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/pulse/v1/namespace-request.json``
 
-        This method takes output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
 
         This method is ``experimental``
         """
@@ -104,37 +104,47 @@ class Pulse(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "claimNamespace": {           'args': ['namespace'],
+        "claimNamespace": {
+            'args': ['namespace'],
             'input': 'http://schemas.taskcluster.net/pulse/v1/namespace-request.json',
             'method': 'post',
             'name': 'claimNamespace',
             'output': 'http://schemas.taskcluster.net/pulse/v1/namespace-response.json',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental'},
-        "listNamespaces": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listNamespaces": {
+            'args': [],
             'method': 'get',
             'name': 'listNamespaces',
             'output': 'http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json',
             'query': ['limit', 'continuation'],
             'route': '/namespaces',
-            'stability': 'experimental'},
-        "namespace": {           'args': ['namespace'],
+            'stability': 'experimental',
+        },
+        "namespace": {
+            'args': ['namespace'],
             'method': 'get',
             'name': 'namespace',
             'output': 'http://schemas.taskcluster.net/pulse/v1/namespace.json',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental'},
-        "overview": {           'args': [],
+            'stability': 'experimental',
+        },
+        "overview": {
+            'args': [],
             'method': 'get',
             'name': 'overview',
             'output': 'http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json',
             'route': '/overview',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/purgecache.py
+++ b/taskcluster/purgecache.py
@@ -50,7 +50,7 @@ class PurgeCache(BaseClient):
         endpoint that is specific to their workerType and
         provisionerId.
 
-        This method takes output: ``http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#``
 
         This method is ``experimental``
         """
@@ -65,7 +65,7 @@ class PurgeCache(BaseClient):
         a certain time. This is safe to be used in automation from
         workers.
 
-        This method takes output: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#``
 
         This method is ``experimental``
         """
@@ -85,31 +85,39 @@ class PurgeCache(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "allPurgeRequests": {           'args': [],
+        "allPurgeRequests": {
+            'args': [],
             'method': 'get',
             'name': 'allPurgeRequests',
             'output': 'http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/purge-cache/list',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "purgeCache": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "purgeCache": {
+            'args': ['provisionerId', 'workerType'],
             'input': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request.json#',
             'method': 'post',
             'name': 'purgeCache',
             'route': '/purge-cache/<provisionerId>/<workerType>',
-            'stability': 'experimental'},
-        "purgeRequests": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "purgeRequests": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'purgeRequests',
             'output': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#',
             'query': ['since'],
             'route': '/purge-cache/<provisionerId>/<workerType>',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/purgecacheevents.py
+++ b/taskcluster/purgecacheevents.py
@@ -25,24 +25,44 @@ class PurgeCacheEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-purge-cache/v1/"
     }
 
-    """
-    Purge Cache Messages
-
-    When a cache purge is requested  a message will be posted on this
-    exchange with designated `provisionerId` and `workerType` in the
-    routing-key and the name of the `cacheFolder` as payload
-
-    This exchange outputs: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * provisionerId: `provisionerId` under which to purge cache. (required)
-
-     * workerType: `workerType` for which to purge cache. (required)
-    """
-
     def purgeCache(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'purge-cache', 'name': 'purgeCache', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` under which to purge cache.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` for which to purge cache.'}], 'schema': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#'}, *args, **kwargs)
+        """
+        Purge Cache Messages
+
+        When a cache purge is requested  a message will be posted on this
+        exchange with designated `provisionerId` and `workerType` in the
+        routing-key and the name of the `cacheFolder` as payload
+
+        This exchange outputs: ``http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * provisionerId: `provisionerId` under which to purge cache. (required)
+
+         * workerType: `workerType` for which to purge cache. (required)
+        """
+
+        ref = {
+            'exchange': 'purge-cache',
+            'name': 'purgeCache',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/purge-cache/v1/purge-cache-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/queue.py
+++ b/taskcluster/queue.py
@@ -36,7 +36,7 @@ class Queue(BaseClient):
         definition may have been modified by queue, if an optional property is
         not specified the queue may provide a default value.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task.json#``
 
         This method is ``stable``
         """
@@ -49,7 +49,7 @@ class Queue(BaseClient):
 
         Get task status structure from `taskId`
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -77,7 +77,7 @@ class Queue(BaseClient):
         If you are not interested in listing all the members at once, you may
         use the query-string option `limit` to return fewer.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#``
 
         This method is ``stable``
         """
@@ -105,7 +105,7 @@ class Queue(BaseClient):
         If you are not interested in listing all the tasks at once, you may
         use the query-string option `limit` to return fewer.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -143,7 +143,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/create-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -159,7 +159,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/create-task-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``deprecated``
         """
@@ -185,7 +185,7 @@ class Queue(BaseClient):
         if called with a `taskId` that is already scheduled, or even resolved.
         To reschedule a task previously resolved, use `rerunTask`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -209,7 +209,7 @@ class Queue(BaseClient):
         is not either `failed` or `completed`, this operation will just return
         the current task status.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``deprecated``
         """
@@ -233,7 +233,7 @@ class Queue(BaseClient):
         isn't `unscheduled`, `pending` or `running`, this operation will just
         return the current task status.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -248,7 +248,7 @@ class Queue(BaseClient):
         Once messages are polled from here, you can claim the referenced task
         with `claimTask`, and afterwards you should always delete the message.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#``
 
         This method is ``stable``
         """
@@ -263,7 +263,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/claim-work-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/claim-work-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/claim-work-response.json#``
 
         This method is ``stable``
         """
@@ -278,7 +278,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/task-claim-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-claim-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-claim-response.json#``
 
         This method is ``stable``
         """
@@ -311,7 +311,7 @@ class Queue(BaseClient):
         should abort the task and forget about the given `runId`. There is no
         need to resolve the run or upload artifacts.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#``
 
         This method is ``stable``
         """
@@ -324,7 +324,7 @@ class Queue(BaseClient):
 
         Report a task completed, resolving the run as `completed`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -343,7 +343,7 @@ class Queue(BaseClient):
         payload, or other unexpected condition. In these cases we have a task
         exception, which should be reported with `reportException`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -370,7 +370,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/task-exception-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/task-status-response.json#``
 
         This method is ``stable``
         """
@@ -442,7 +442,7 @@ class Queue(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#``
 
         This method is ``stable``
         """
@@ -516,7 +516,7 @@ class Queue(BaseClient):
         By default this end-point will list up-to 1000 artifacts in a single page
         you may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
 
         This method is ``experimental``
         """
@@ -538,7 +538,7 @@ class Queue(BaseClient):
         By default this end-point will list up-to 1000 artifacts in a single page
         you may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#``
 
         This method is ``experimental``
         """
@@ -560,7 +560,7 @@ class Queue(BaseClient):
         option. By default this end-point will list up to 1000 provisioners in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#``
 
         This method is ``experimental``
         """
@@ -579,7 +579,7 @@ class Queue(BaseClient):
         should be no means expect this to be an accurate number.
         It is, however, a solid estimate of the number of pending tasks.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#``
 
         This method is ``stable``
         """
@@ -597,7 +597,7 @@ class Queue(BaseClient):
         option. By default this end-point will list up to 1000 worker-types in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#``
 
         This method is ``experimental``
         """
@@ -615,7 +615,7 @@ class Queue(BaseClient):
         option. By default this end-point will list up to 1000 workers in a single
         page. You may limit this with the query-string parameter `limit`.
 
-        This method takes output: ``http://schemas.taskcluster.net/queue/v1/list-workers-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/queue/v1/list-workers-response.json#``
 
         This method is ``experimental``
         """
@@ -635,172 +635,224 @@ class Queue(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "cancelTask": {           'args': ['taskId'],
+        "cancelTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'cancelTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/cancel',
-            'stability': 'stable'},
-        "claimTask": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "claimTask": {
+            'args': ['taskId', 'runId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/task-claim-request.json#',
             'method': 'post',
             'name': 'claimTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-claim-response.json#',
             'route': '/task/<taskId>/runs/<runId>/claim',
-            'stability': 'stable'},
-        "claimWork": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "claimWork": {
+            'args': ['provisionerId', 'workerType'],
             'input': 'http://schemas.taskcluster.net/queue/v1/claim-work-request.json#',
             'method': 'post',
             'name': 'claimWork',
             'output': 'http://schemas.taskcluster.net/queue/v1/claim-work-response.json#',
             'route': '/claim-work/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "createArtifact": {           'args': ['taskId', 'runId', 'name'],
+            'stability': 'stable',
+        },
+        "createArtifact": {
+            'args': ['taskId', 'runId', 'name'],
             'input': 'http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#',
             'method': 'post',
             'name': 'createArtifact',
             'output': 'http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#',
             'route': '/task/<taskId>/runs/<runId>/artifacts/<name>',
-            'stability': 'stable'},
-        "createTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "createTask": {
+            'args': ['taskId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/create-task-request.json#',
             'method': 'put',
             'name': 'createTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>',
-            'stability': 'stable'},
-        "defineTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "defineTask": {
+            'args': ['taskId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/create-task-request.json#',
             'method': 'post',
             'name': 'defineTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/define',
-            'stability': 'deprecated'},
-        "getArtifact": {           'args': ['taskId', 'runId', 'name'],
+            'stability': 'deprecated',
+        },
+        "getArtifact": {
+            'args': ['taskId', 'runId', 'name'],
             'method': 'get',
             'name': 'getArtifact',
             'route': '/task/<taskId>/runs/<runId>/artifacts/<name>',
-            'stability': 'stable'},
-        "getLatestArtifact": {           'args': ['taskId', 'name'],
+            'stability': 'stable',
+        },
+        "getLatestArtifact": {
+            'args': ['taskId', 'name'],
             'method': 'get',
             'name': 'getLatestArtifact',
             'route': '/task/<taskId>/artifacts/<name>',
-            'stability': 'stable'},
-        "listArtifacts": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "listArtifacts": {
+            'args': ['taskId', 'runId'],
             'method': 'get',
             'name': 'listArtifacts',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/runs/<runId>/artifacts',
-            'stability': 'experimental'},
-        "listDependentTasks": {           'args': ['taskId'],
+            'stability': 'experimental',
+        },
+        "listDependentTasks": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'listDependentTasks',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/dependents',
-            'stability': 'stable'},
-        "listLatestArtifacts": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "listLatestArtifacts": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'listLatestArtifacts',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task/<taskId>/artifacts',
-            'stability': 'experimental'},
-        "listProvisioners": {           'args': [],
+            'stability': 'experimental',
+        },
+        "listProvisioners": {
+            'args': [],
             'method': 'get',
             'name': 'listProvisioners',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners',
-            'stability': 'experimental'},
-        "listTaskGroup": {           'args': ['taskGroupId'],
+            'stability': 'experimental',
+        },
+        "listTaskGroup": {
+            'args': ['taskGroupId'],
             'method': 'get',
             'name': 'listTaskGroup',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task-group/<taskGroupId>/list',
-            'stability': 'stable'},
-        "listWorkerTypes": {           'args': ['provisionerId'],
+            'stability': 'stable',
+        },
+        "listWorkerTypes": {
+            'args': ['provisionerId'],
             'method': 'get',
             'name': 'listWorkerTypes',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners/<provisionerId>/worker-types',
-            'stability': 'experimental'},
-        "listWorkers": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "listWorkers": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'listWorkers',
             'output': 'http://schemas.taskcluster.net/queue/v1/list-workers-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/provisioners/<provisionerId>/worker-types/<workerType>/workers',
-            'stability': 'experimental'},
-        "pendingTasks": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'experimental',
+        },
+        "pendingTasks": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'pendingTasks',
             'output': 'http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#',
             'route': '/pending/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "pollTaskUrls": {           'args': ['provisionerId', 'workerType'],
+            'stability': 'stable',
+        },
+        "pollTaskUrls": {
+            'args': ['provisionerId', 'workerType'],
             'method': 'get',
             'name': 'pollTaskUrls',
             'output': 'http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#',
             'route': '/poll-task-url/<provisionerId>/<workerType>',
-            'stability': 'stable'},
-        "reclaimTask": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reclaimTask": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reclaimTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#',
             'route': '/task/<taskId>/runs/<runId>/reclaim',
-            'stability': 'stable'},
-        "reportCompleted": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportCompleted": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reportCompleted',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/completed',
-            'stability': 'stable'},
-        "reportException": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportException": {
+            'args': ['taskId', 'runId'],
             'input': 'http://schemas.taskcluster.net/queue/v1/task-exception-request.json#',
             'method': 'post',
             'name': 'reportException',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/exception',
-            'stability': 'stable'},
-        "reportFailed": {           'args': ['taskId', 'runId'],
+            'stability': 'stable',
+        },
+        "reportFailed": {
+            'args': ['taskId', 'runId'],
             'method': 'post',
             'name': 'reportFailed',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/runs/<runId>/failed',
-            'stability': 'stable'},
-        "rerunTask": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "rerunTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'rerunTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/rerun',
-            'stability': 'deprecated'},
-        "scheduleTask": {           'args': ['taskId'],
+            'stability': 'deprecated',
+        },
+        "scheduleTask": {
+            'args': ['taskId'],
             'method': 'post',
             'name': 'scheduleTask',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/schedule',
-            'stability': 'stable'},
-        "status": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "status": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'status',
             'output': 'http://schemas.taskcluster.net/queue/v1/task-status-response.json#',
             'route': '/task/<taskId>/status',
-            'stability': 'stable'},
-        "task": {           'args': ['taskId'],
+            'stability': 'stable',
+        },
+        "task": {
+            'args': ['taskId'],
             'method': 'get',
             'name': 'task',
             'output': 'http://schemas.taskcluster.net/queue/v1/task.json#',
             'route': '/task/<taskId>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/queueevents.py
+++ b/taskcluster/queueevents.py
@@ -66,288 +66,648 @@ class QueueEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-queue/v1/"
     }
 
-    """
-    Task Defined Messages
-
-    When a task is created or just defined a message is posted to this
-    exchange.
-
-    This message exchange is mainly useful when tasks are scheduled by a
-    scheduler that uses `defineTask` as this does not make the task
-    `pending`. Thus, no `taskPending` message is published.
-    Please, note that messages are also published on this exchange if defined
-    using `createTask`.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-defined-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * taskId: `taskId` for the task this message concerns (required)
-
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
-
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
-
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
-
-     * provisionerId: `provisionerId` this task is targeted at. (required)
-
-     * workerType: `workerType` this task must run on. (required)
-
-     * schedulerId: `schedulerId` this task was created by. (required)
-
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def taskDefined(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-defined', 'name': 'taskDefined', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-defined-message.json#'}, *args, **kwargs)
+        """
+        Task Defined Messages
 
-    """
-    Task Pending Messages
+        When a task is created or just defined a message is posted to this
+        exchange.
 
-    When a task becomes `pending` a message is posted to this exchange.
+        This message exchange is mainly useful when tasks are scheduled by a
+        scheduler that uses `defineTask` as this does not make the task
+        `pending`. Thus, no `taskPending` message is published.
+        Please, note that messages are also published on this exchange if defined
+        using `createTask`.
 
-    This is useful for workers who doesn't want to constantly poll the queue
-    for new tasks. The queue will also be authority for task states and
-    claims. But using this exchange workers should be able to distribute work
-    efficiently and they would be able to reduce their polling interval
-    significantly without affecting general responsiveness.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-defined-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-pending-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-defined',
+            'name': 'taskDefined',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-defined-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskPending(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-pending', 'name': 'taskPending', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-pending-message.json#'}, *args, **kwargs)
+        """
+        Task Pending Messages
 
-    """
-    Task Running Messages
+        When a task becomes `pending` a message is posted to this exchange.
 
-    Whenever a task is claimed by a worker, a run is started on the worker,
-    and a message is posted on this exchange.
+        This is useful for workers who doesn't want to constantly poll the queue
+        for new tasks. The queue will also be authority for task states and
+        claims. But using this exchange workers should be able to distribute work
+        efficiently and they would be able to reduce their polling interval
+        significantly without affecting general responsiveness.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-running-message.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-pending-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-pending',
+            'name': 'taskPending',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-pending-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskRunning(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-running', 'name': 'taskRunning', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-running-message.json#'}, *args, **kwargs)
+        """
+        Task Running Messages
 
-    """
-    Artifact Creation Messages
+        Whenever a task is claimed by a worker, a run is started on the worker,
+        and a message is posted on this exchange.
 
-    Whenever the `createArtifact` end-point is called, the queue will create
-    a record of the artifact and post a message on this exchange. All of this
-    happens before the queue returns a signed URL for the caller to upload
-    the actual artifact with (pending on `storageType`).
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-running-message.json#``This exchange takes the following keys:
 
-    This means that the actual artifact is rarely available when this message
-    is posted. But it is not unreasonable to assume that the artifact will
-    will become available at some point later. Most signatures will expire in
-    30 minutes or so, forcing the uploader to call `createArtifact` with
-    the same payload again in-order to continue uploading the artifact.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    However, in most cases (especially for small artifacts) it's very
-    reasonable assume the artifact will be available within a few minutes.
-    This property means that this exchange is mostly useful for tools
-    monitoring task evaluation. One could also use it count number of
-    artifacts per task, or _index_ artifacts though in most cases it'll be
-    smarter to index artifacts after the task in question have completed
-    successfully.
+         * taskId: `taskId` for the task this message concerns (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#``This exchange takes the following keys:
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * schedulerId: `schedulerId` this task was created by. (required)
-
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-running',
+            'name': 'taskRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-running-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def artifactCreated(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'artifact-created', 'name': 'artifactCreated', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#'}, *args, **kwargs)
+        """
+        Artifact Creation Messages
 
-    """
-    Task Completed Messages
+        Whenever the `createArtifact` end-point is called, the queue will create
+        a record of the artifact and post a message on this exchange. All of this
+        happens before the queue returns a signed URL for the caller to upload
+        the actual artifact with (pending on `storageType`).
 
-    When a task is successfully completed by a worker a message is posted
-    this exchange.
-    This message is routed using the `runId`, `workerGroup` and `workerId`
-    that completed the task. But information about additional runs is also
-    available from the task status structure.
+        This means that the actual artifact is rarely available when this message
+        is posted. But it is not unreasonable to assume that the artifact will
+        will become available at some point later. Most signatures will expire in
+        30 minutes or so, forcing the uploader to call `createArtifact` with
+        the same payload again in-order to continue uploading the artifact.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-completed-message.json#``This exchange takes the following keys:
+        However, in most cases (especially for small artifacts) it's very
+        reasonable assume the artifact will be available within a few minutes.
+        This property means that this exchange is mostly useful for tools
+        monitoring task evaluation. One could also use it count number of
+        artifacts per task, or _index_ artifacts though in most cases it'll be
+        smarter to index artifacts after the task in question have completed
+        successfully.
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#``This exchange takes the following keys:
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * taskGroupId: `taskGroupId` this task was created in. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'artifact-created',
+            'name': 'artifactCreated',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskCompleted(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-completed', 'name': 'taskCompleted', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': True, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': True, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': True, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-completed-message.json#'}, *args, **kwargs)
+        """
+        Task Completed Messages
 
-    """
-    Task Failed Messages
+        When a task is successfully completed by a worker a message is posted
+        this exchange.
+        This message is routed using the `runId`, `workerGroup` and `workerId`
+        that completed the task. But information about additional runs is also
+        available from the task status structure.
 
-    When a task ran, but failed to complete successfully a message is posted
-    to this exchange. This is same as worker ran task-specific code, but the
-    task specific code exited non-zero.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-completed-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-failed-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * workerType: `workerType` this task must run on. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-completed',
+            'name': 'taskCompleted',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-completed-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskFailed(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-failed', 'name': 'taskFailed', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-failed-message.json#'}, *args, **kwargs)
+        """
+        Task Failed Messages
 
-    """
-    Task Exception Messages
+        When a task ran, but failed to complete successfully a message is posted
+        to this exchange. This is same as worker ran task-specific code, but the
+        task specific code exited non-zero.
 
-    Whenever Taskcluster fails to run a message is posted to this exchange.
-    This happens if the task isn't completed before its `deadlìne`,
-    all retries failed (i.e. workers stopped responding), the task was
-    canceled by another entity, or the task carried a malformed payload.
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-failed-message.json#``This exchange takes the following keys:
 
-    The specific _reason_ is evident from that task status structure, refer
-    to the `reasonResolved` property for the last run.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-exception-message.json#``This exchange takes the following keys:
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * taskId: `taskId` for the task this message concerns (required)
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
 
-     * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
 
-     * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+         * provisionerId: `provisionerId` this task is targeted at. (required)
 
-     * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+         * workerType: `workerType` this task must run on. (required)
 
-     * provisionerId: `provisionerId` this task is targeted at. (required)
+         * schedulerId: `schedulerId` this task was created by. (required)
 
-     * workerType: `workerType` this task must run on. (required)
+         * taskGroupId: `taskGroupId` this task was created in. (required)
 
-     * schedulerId: `schedulerId` this task was created by. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * taskGroupId: `taskGroupId` this task was created in. (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-failed',
+            'name': 'taskFailed',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-failed-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskException(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-exception', 'name': 'taskException', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': True, 'summary': '`taskId` for the task this message concerns'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': '`runId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': '`workerGroup` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': '`workerId` of latest run for the task, `_` if no run is exists for the task.'}, {'multipleWords': False, 'name': 'provisionerId', 'required': True, 'summary': '`provisionerId` this task is targeted at.'}, {'multipleWords': False, 'name': 'workerType', 'required': True, 'summary': '`workerType` this task must run on.'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` this task was created by.'}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` this task was created in.'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-exception-message.json#'}, *args, **kwargs)
+        """
+        Task Exception Messages
 
-    """
-    Task Group Resolved Messages
+        Whenever Taskcluster fails to run a message is posted to this exchange.
+        This happens if the task isn't completed before its `deadlìne`,
+        all retries failed (i.e. workers stopped responding), the task was
+        canceled by another entity, or the task carried a malformed payload.
 
-    A message is published on task-group-resolved whenever all submitted
-    tasks (whether scheduled or unscheduled) for a given task group have
-    been resolved, regardless of whether they resolved as successful or
-    not. A task group may be resolved multiple times, since new tasks may
-    be submitted against an already resolved task group.
+        The specific _reason_ is evident from that task status structure, refer
+        to the `reasonResolved` property for the last run.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-exception-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskGroupId: `taskGroupId` for the task-group this message concerns (required)
+         * taskId: `taskId` for the task this message concerns (required)
 
-     * schedulerId: `schedulerId` for the task-group this message concerns (required)
+         * runId: `runId` of latest run for the task, `_` if no run is exists for the task.
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * workerGroup: `workerGroup` of latest run for the task, `_` if no run is exists for the task.
+
+         * workerId: `workerId` of latest run for the task, `_` if no run is exists for the task.
+
+         * provisionerId: `provisionerId` this task is targeted at. (required)
+
+         * workerType: `workerType` this task must run on. (required)
+
+         * schedulerId: `schedulerId` this task was created by. (required)
+
+         * taskGroupId: `taskGroupId` this task was created in. (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-exception',
+            'name': 'taskException',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-exception-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGroupResolved(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-group-resolved', 'name': 'taskGroupResolved', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskGroupId', 'required': True, 'summary': '`taskGroupId` for the task-group this message concerns'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': '`schedulerId` for the task-group this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#'}, *args, **kwargs)
+        """
+        Task Group Resolved Messages
+
+        A message is published on task-group-resolved whenever all submitted
+        tasks (whether scheduled or unscheduled) for a given task group have
+        been resolved, regardless of whether they resolved as successful or
+        not. A task group may be resolved multiple times, since new tasks may
+        be submitted against an already resolved task group.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * taskGroupId: `taskGroupId` for the task-group this message concerns (required)
+
+         * schedulerId: `schedulerId` for the task-group this message concerns (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-group-resolved',
+            'name': 'taskGroupResolved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGroupId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/queue/v1/task-group-resolved.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/scheduler.py
+++ b/taskcluster/scheduler.py
@@ -99,7 +99,7 @@ class Scheduler(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/scheduler/v1/task-graph.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
 
         This method is ``experimental``
         """
@@ -126,7 +126,7 @@ class Scheduler(BaseClient):
 
         This method takes input: ``http://schemas.taskcluster.net/scheduler/v1/extend-task-graph-request.json#``
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#``
 
         This method is ``experimental``
         """
@@ -143,7 +143,7 @@ class Scheduler(BaseClient):
 
         **Note**, that `finished` implies successfully completion.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json``
 
         This method is ``experimental``
         """
@@ -161,7 +161,7 @@ class Scheduler(BaseClient):
         If you want more detailed information use the `inspectTaskGraph`
         end-point instead.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json``
 
         This method is ``experimental``
         """
@@ -185,7 +185,7 @@ class Scheduler(BaseClient):
         as we do not promise it will remain fully backward compatible in
         the future.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json``
 
         This method is ``experimental``
         """
@@ -209,7 +209,7 @@ class Scheduler(BaseClient):
         as we do not promise it will remain fully backward compatible in
         the future.
 
-        This method takes output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json``
+        This method gives output: ``http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json``
 
         This method is ``experimental``
         """
@@ -230,49 +230,63 @@ class Scheduler(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "createTaskGraph": {           'args': ['taskGraphId'],
+        "createTaskGraph": {
+            'args': ['taskGraphId'],
             'input': 'http://schemas.taskcluster.net/scheduler/v1/task-graph.json#',
             'method': 'put',
             'name': 'createTaskGraph',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#',
             'route': '/task-graph/<taskGraphId>',
-            'stability': 'experimental'},
-        "extendTaskGraph": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "extendTaskGraph": {
+            'args': ['taskGraphId'],
             'input': 'http://schemas.taskcluster.net/scheduler/v1/extend-task-graph-request.json#',
             'method': 'post',
             'name': 'extendTaskGraph',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json#',
             'route': '/task-graph/<taskGraphId>/extend',
-            'stability': 'experimental'},
-        "info": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "info": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'info',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-info-response.json',
             'route': '/task-graph/<taskGraphId>/info',
-            'stability': 'experimental'},
-        "inspect": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "inspect": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'inspect',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-response.json',
             'route': '/task-graph/<taskGraphId>/inspect',
-            'stability': 'experimental'},
-        "inspectTask": {           'args': ['taskGraphId', 'taskId'],
+            'stability': 'experimental',
+        },
+        "inspectTask": {
+            'args': ['taskGraphId', 'taskId'],
             'method': 'get',
             'name': 'inspectTask',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/inspect-task-graph-task-response.json',
             'route': '/task-graph/<taskGraphId>/inspect/<taskId>',
-            'stability': 'experimental'},
-        "ping": {           'args': [],
+            'stability': 'experimental',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'experimental'},
-        "status": {           'args': ['taskGraphId'],
+            'stability': 'experimental',
+        },
+        "status": {
+            'args': ['taskGraphId'],
             'method': 'get',
             'name': 'status',
             'output': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-status-response.json',
             'route': '/task-graph/<taskGraphId>/status',
-            'stability': 'experimental'},
+            'stability': 'experimental',
+        },
     }
 
 

--- a/taskcluster/schedulerevents.py
+++ b/taskcluster/schedulerevents.py
@@ -44,143 +44,335 @@ class SchedulerEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-scheduler/v1/"
     }
 
-    """
-    Task-Graph Running Message
-
-    When a task-graph is submitted it immediately starts running and a
-    message is posted on this exchange to indicate that a task-graph have
-    been submitted.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#``This exchange takes the following keys:
-
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
-
-     * taskId: Always takes the value `_`
-
-     * runId: Always takes the value `_`
-
-     * workerGroup: Always takes the value `_`
-
-     * workerId: Always takes the value `_`
-
-     * provisionerId: Always takes the value `_`
-
-     * workerType: Always takes the value `_`
-
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
-
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def taskGraphRunning(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-running', 'name': 'taskGraphRunning', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Running Message
 
-    """
-    Task-Graph Extended Message
+        When a task-graph is submitted it immediately starts running and a
+        message is posted on this exchange to indicate that a task-graph have
+        been submitted.
 
-    When a task-graph is extended, that is additional tasks is added to the
-    task-graph, a message is posted on this exchange. This is useful if you
-    are monitoring a task-graph and what to track states of the individual
-    tasks in the task-graph.
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#``This exchange takes the following keys:
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#``This exchange takes the following keys:
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * taskId: Always takes the value `_`
 
-     * taskId: Always takes the value `_`
+         * runId: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * workerType: Always takes the value `_`
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-graph-running',
+            'name': 'taskGraphRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-running-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphExtended(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-extended', 'name': 'taskGraphExtended', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Extended Message
 
-    """
-    Task-Graph Blocked Message
+        When a task-graph is extended, that is additional tasks is added to the
+        task-graph, a message is posted on this exchange. This is useful if you
+        are monitoring a task-graph and what to track states of the individual
+        tasks in the task-graph.
 
-    When a task is completed unsuccessfully and all reruns have been
-    attempted, the task-graph will not complete successfully and it's
-    declared to be _blocked_, by some task that consistently completes
-    unsuccessfully.
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#``This exchange takes the following keys:
 
-    When a task-graph becomes blocked a messages is posted to this exchange.
-    The message features the `taskId` of the task that caused the task-graph
-    to become blocked.
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#``This exchange takes the following keys:
+         * taskId: Always takes the value `_`
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * runId: Always takes the value `_`
 
-     * taskId: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * workerType: Always takes the value `_`
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+        ref = {
+            'exchange': 'task-graph-extended',
+            'name': 'taskGraphExtended',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-extended-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphBlocked(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-blocked', 'name': 'taskGraphBlocked', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Blocked Message
 
-    """
-    Task-Graph Finished Message
+        When a task is completed unsuccessfully and all reruns have been
+        attempted, the task-graph will not complete successfully and it's
+        declared to be _blocked_, by some task that consistently completes
+        unsuccessfully.
 
-    When all tasks of a task-graph have completed successfully, the
-    task-graph is declared to be finished, and a message is posted to this
-    exchange.
+        When a task-graph becomes blocked a messages is posted to this exchange.
+        The message features the `taskId` of the task that caused the task-graph
+        to become blocked.
 
-    This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#``This exchange takes the following keys:
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#``This exchange takes the following keys:
 
-     * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-     * taskId: Always takes the value `_`
+         * taskId: Always takes the value `_`
 
-     * runId: Always takes the value `_`
+         * runId: Always takes the value `_`
 
-     * workerGroup: Always takes the value `_`
+         * workerGroup: Always takes the value `_`
 
-     * workerId: Always takes the value `_`
+         * workerId: Always takes the value `_`
 
-     * provisionerId: Always takes the value `_`
+         * provisionerId: Always takes the value `_`
 
-     * workerType: Always takes the value `_`
+         * workerType: Always takes the value `_`
 
-     * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
 
-     * taskGraphId: Identifier for the task-graph this message concerns (required)
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
 
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-graph-blocked',
+            'name': 'taskGraphBlocked',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-blocked-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     def taskGraphFinished(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'task-graph-finished', 'name': 'taskGraphFinished', 'routingKey': [{'constant': 'primary', 'multipleWords': False, 'name': 'routingKeyKind', 'required': True, 'summary': "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."}, {'multipleWords': False, 'name': 'taskId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'runId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerGroup', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'provisionerId', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'workerType', 'required': False, 'summary': 'Always takes the value `_`'}, {'multipleWords': False, 'name': 'schedulerId', 'required': True, 'summary': 'Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production.'}, {'multipleWords': False, 'name': 'taskGraphId', 'required': True, 'summary': 'Identifier for the task-graph this message concerns'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#'}, *args, **kwargs)
+        """
+        Task-Graph Finished Message
+
+        When all tasks of a task-graph have completed successfully, the
+        task-graph is declared to be finished, and a message is posted to this
+        exchange.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#``This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * taskId: Always takes the value `_`
+
+         * runId: Always takes the value `_`
+
+         * workerGroup: Always takes the value `_`
+
+         * workerId: Always takes the value `_`
+
+         * provisionerId: Always takes the value `_`
+
+         * workerType: Always takes the value `_`
+
+         * schedulerId: Identifier for the task-graphs scheduler managing the task-graph this message concerns. Usually `task-graph-scheduler` in production. (required)
+
+         * taskGraphId: Identifier for the task-graph this message concerns (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'task-graph-finished',
+            'name': 'taskGraphFinished',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'runId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'schedulerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'taskGraphId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/scheduler/v1/task-graph-finished-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/taskcluster/secrets.py
+++ b/taskcluster/secrets.py
@@ -60,7 +60,7 @@ class Secrets(BaseClient):
         scope necessary to get the secret, the call will fail with a 403 code
         regardless of whether the secret exists.
 
-        This method takes output: ``http://schemas.taskcluster.net/secrets/v1/secret.json#``
+        This method gives output: ``http://schemas.taskcluster.net/secrets/v1/secret.json#``
 
         This method is ``stable``
         """
@@ -75,7 +75,7 @@ class Secrets(BaseClient):
         other words, secret name `<X>` will only be returned if a) a secret
         with name `<X>` exists, and b) you posses the scope `secrets:get:<X>`.
 
-        This method takes output: ``http://schemas.taskcluster.net/secrets/v1/secret-list.json#``
+        This method gives output: ``http://schemas.taskcluster.net/secrets/v1/secret-list.json#``
 
         This method is ``stable``
         """
@@ -95,34 +95,44 @@ class Secrets(BaseClient):
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     funcinfo = {
-        "get": {           'args': ['name'],
+        "get": {
+            'args': ['name'],
             'method': 'get',
             'name': 'get',
             'output': 'http://schemas.taskcluster.net/secrets/v1/secret.json#',
             'route': '/secret/<name>',
-            'stability': 'stable'},
-        "list": {           'args': [],
+            'stability': 'stable',
+        },
+        "list": {
+            'args': [],
             'method': 'get',
             'name': 'list',
             'output': 'http://schemas.taskcluster.net/secrets/v1/secret-list.json#',
             'route': '/secrets',
-            'stability': 'stable'},
-        "ping": {           'args': [],
+            'stability': 'stable',
+        },
+        "ping": {
+            'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
-            'stability': 'stable'},
-        "remove": {           'args': ['name'],
+            'stability': 'stable',
+        },
+        "remove": {
+            'args': ['name'],
             'method': 'delete',
             'name': 'remove',
             'route': '/secret/<name>',
-            'stability': 'stable'},
-        "set": {           'args': ['name'],
+            'stability': 'stable',
+        },
+        "set": {
+            'args': ['name'],
             'input': 'http://schemas.taskcluster.net/secrets/v1/secret.json#',
             'method': 'put',
             'name': 'set',
             'route': '/secret/<name>',
-            'stability': 'stable'},
+            'stability': 'stable',
+        },
     }
 
 

--- a/taskcluster/treeherderevents.py
+++ b/taskcluster/treeherderevents.py
@@ -26,23 +26,42 @@ class TreeherderEvents(BaseClient):
         "exchangePrefix": "exchange/taskcluster-treeherder/v1/"
     }
 
-    """
-    Job Messages
-
-    When a task run is scheduled or resolved, a message is posted to
-    this exchange in a Treeherder consumable format.
-
-    This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
-
-     * destination: destination (required)
-
-     * project: project (required)
-
-     * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
-    """
-
     def jobs(self, *args, **kwargs):
-        return self._makeTopicExchange({'exchange': 'jobs', 'name': 'jobs', 'routingKey': [{'multipleWords': False, 'name': 'destination', 'required': True, 'summary': 'destination'}, {'multipleWords': False, 'name': 'project', 'required': True, 'summary': 'project'}, {'multipleWords': True, 'name': 'reserved', 'required': False, 'summary': 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'}], 'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#'}, *args, **kwargs)
+        """
+        Job Messages
+
+        When a task run is scheduled or resolved, a message is posted to
+        this exchange in a Treeherder consumable format.
+
+        This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
+
+         * destination: destination (required)
+
+         * project: project (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'jobs',
+            'name': 'jobs',
+            'routingKey': [
+                {
+                    'multipleWords': False,
+                    'name': 'destination',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'project',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
 
     funcinfo = {
     }

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -96,10 +96,10 @@ class TestSubArgsInRoute(ClientTest):
 class TestProcessArgs(ClientTest):
 
     def test_no_args(self):
-        self.assertEqual(({}, None, {}), self.client._processArgs({'args': [], 'name': 'test'}))
+        self.assertEqual(({}, None, {}, None, None), self.client._processArgs({'args': [], 'name': 'test'}))
 
     def test_finds_payload(self):
-        expected = ({}, {'a': 123}, {})
+        expected = ({}, {'a': 123}, {}, None, None)
         actual = self.client._processArgs({'args': [], 'name': 'test', 'input': True}, {'a': 123})
         self.assertEqual(expected, actual)
 
@@ -107,19 +107,19 @@ class TestProcessArgs(ClientTest):
         expected = {'test': 'works', 'test2': 'still works'}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, 'works', 'still works')
-        self.assertEqual((expected, None, {}), actual)
+        self.assertEqual((expected, None, {}, None, None), actual)
 
     def test_keyword_args_only(self):
         expected = {'test': 'works', 'test2': 'still works'}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, test2='still works', test='works')
-        self.assertEqual((expected, None, {}), actual)
+        self.assertEqual((expected, None, {}, None, None), actual)
 
     def test_int_args(self):
         expected = {'test': 'works', 'test2': 42}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, 'works', 42)
-        self.assertEqual((expected, None, {}), actual)
+        self.assertEqual((expected, None, {}, None, None), actual)
 
     def test_keyword_and_positional(self):
         entry = {'args': ['test'], 'name': 'test'}
@@ -161,64 +161,72 @@ class TestProcessArgs(ClientTest):
             self.client._processArgs({'args': ['test'], 'name': 'test'}, {'john': 'ford'})
 
     def test_calling_convention_1_without_payload(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2)
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2)
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, None)
         self.assertEqual(query, {})
 
     def test_calling_convention_1_with_payload(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, 1, 2, {'A': 123})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, 1, 2, {'A': 123})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, {'A': 123})
         self.assertEqual(query, {})
 
     def test_calling_convention_2_without_payload(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, k1=1, k2=2)
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, k1=1, k2=2)
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, None)
         self.assertEqual(query, {})
 
     def test_calling_convention_2_with_payload(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, {'A': 123}, k1=1, k2=2)
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, {'A': 123}, k1=1, k2=2)
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, {'A': 123})
         self.assertEqual(query, {})
 
     def test_calling_convention_3_without_payload_without_query(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, None)
         self.assertEqual(query, {})
 
     def test_calling_convention_3_with_payload_without_query(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, {'A': 123})
         self.assertEqual(query, {})
 
     def test_calling_convention_3_with_payload_with_query(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123}, query={'B': 456})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123}, query={'B': 456})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, {'A': 123})
         self.assertEqual(query, {'B': 456})
 
     def test_calling_convention_3_without_payload_with_query(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, query={'B': 456})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, query={'B': 456})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, None)
         self.assertEqual(query, {'B': 456})
 
 
     def test_calling_convention_3_with_positional_arguments_with_payload_with_query(self):
-        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, query={'B': 456}, payload={'A': 123})
+        params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, query={'B': 456}, payload={'A': 123})
         self.assertEqual(params, {'k1': 1, 'k2': 2})
         self.assertEqual(payload, {'A': 123})
         self.assertEqual(query, {'B': 456})
 
+    def test_calling_convention_3_with_pagination(self):
+        a = lambda x: x
+        _, _, _, ph, _ = self.client._processArgs({
+            'args': ['k1', 'k2'],
+            'name': 'test',
+            'query': ['continuationToken', 'limit'],
+        }, 1, 2, paginationHandler=a)
+        self.assertIs(ph, a)
 
     def test_calling_convention_3_with_positional_arguments_which_are_same_as_param_kwarg_dict_values_with_payload_with_query(self):
         with self.assertRaises(exc.TaskclusterFailure):
-            params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, params={'k1': 1, 'k2': 2}, query={'B': 456}, payload={'A': 123})
+            params, payload, query, _, _ = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, params={'k1': 1, 'k2': 2}, query={'B': 456}, payload={'A': 123})
 
 # This could probably be done better with Mock
 class ObjWithDotJson(object):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -519,6 +519,19 @@ class TestBuildUrl(ClientTest):
         actual = self.client.buildUrl('two_args_no_input', arg0='arg0', arg1='arg1')
         self.assertEqual(expected, actual)
 
+    def test_build_url_query_string(self):
+        expected = 'https://fake.taskcluster.net/v1/two_args_no_input/arg0/arg1?qs0=1'
+        actual = self.client.buildUrl(
+            'two_args_no_input',
+            params={
+                'arg0': 'arg0',
+                'arg1': 'arg1'
+            },
+            query={'qs0': 1}
+        )
+        self.assertEqual(expected, actual)
+
+
     def test_fails_to_build_url_for_missing_method(self):
         with self.assertRaises(exc.TaskclusterFailure):
             self.client.buildUrl('non-existing')

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -96,30 +96,35 @@ class TestSubArgsInRoute(ClientTest):
 class TestProcessArgs(ClientTest):
 
     def test_no_args(self):
-        self.assertEqual({}, self.client._processArgs({'args': [], 'name': 'test'}))
+        self.assertEqual(({}, None, {}), self.client._processArgs({'args': [], 'name': 'test'}))
+
+    def test_finds_payload(self):
+        expected = ({}, {'a': 123}, {})
+        actual = self.client._processArgs({'args': [], 'name': 'test', 'input': True}, {'a': 123})
+        self.assertEqual(expected, actual)
 
     def test_positional_args_only(self):
         expected = {'test': 'works', 'test2': 'still works'}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, 'works', 'still works')
-        self.assertEqual(expected, actual)
+        self.assertEqual((expected, None, {}), actual)
 
     def test_keyword_args_only(self):
         expected = {'test': 'works', 'test2': 'still works'}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, test2='still works', test='works')
-        self.assertEqual(expected, actual)
+        self.assertEqual((expected, None, {}), actual)
 
     def test_int_args(self):
         expected = {'test': 'works', 'test2': 42}
         entry = {'args': ['test', 'test2'], 'name': 'test'}
         actual = self.client._processArgs(entry, 'works', 42)
-        self.assertEqual(expected, actual)
+        self.assertEqual((expected, None, {}), actual)
 
     def test_keyword_and_positional(self):
         entry = {'args': ['test'], 'name': 'test'}
         with self.assertRaises(exc.TaskclusterFailure):
-            self.client._processArgs(entry, 'broken', test='works')
+            self.client._processArgs(entry, ['broken'], test='works')
 
     def test_invalid_not_enough_args(self):
         with self.assertRaises(exc.TaskclusterFailure):
@@ -155,6 +160,65 @@ class TestProcessArgs(ClientTest):
         with self.assertRaises(exc.TaskclusterFailure):
             self.client._processArgs({'args': ['test'], 'name': 'test'}, {'john': 'ford'})
 
+    def test_calling_convention_1_without_payload(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2)
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, None)
+        self.assertEqual(query, {})
+
+    def test_calling_convention_1_with_payload(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, 1, 2, {'A': 123})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, {'A': 123})
+        self.assertEqual(query, {})
+
+    def test_calling_convention_2_without_payload(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, k1=1, k2=2)
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, None)
+        self.assertEqual(query, {})
+
+    def test_calling_convention_2_with_payload(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test', 'input': True}, {'A': 123}, k1=1, k2=2)
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, {'A': 123})
+        self.assertEqual(query, {})
+
+    def test_calling_convention_3_without_payload_without_query(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, None)
+        self.assertEqual(query, {})
+
+    def test_calling_convention_3_with_payload_without_query(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, {'A': 123})
+        self.assertEqual(query, {})
+
+    def test_calling_convention_3_with_payload_with_query(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, payload={'A': 123}, query={'B': 456})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, {'A': 123})
+        self.assertEqual(query, {'B': 456})
+
+    def test_calling_convention_3_without_payload_with_query(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, params={'k1': 1, 'k2': 2}, query={'B': 456})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, None)
+        self.assertEqual(query, {'B': 456})
+
+
+    def test_calling_convention_3_with_positional_arguments_with_payload_with_query(self):
+        params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, query={'B': 456}, payload={'A': 123})
+        self.assertEqual(params, {'k1': 1, 'k2': 2})
+        self.assertEqual(payload, {'A': 123})
+        self.assertEqual(query, {'B': 456})
+
+
+    def test_calling_convention_3_with_positional_arguments_which_are_same_as_param_kwarg_dict_values_with_payload_with_query(self):
+        with self.assertRaises(exc.TaskclusterFailure):
+            params, payload, query = self.client._processArgs({'args': ['k1', 'k2'], 'name': 'test'}, 1, 2, params={'k1': 1, 'k2': 2}, query={'B': 456}, payload={'A': 123})
 
 # This could probably be done better with Mock
 class ObjWithDotJson(object):


### PR DESCRIPTION
Here's the initial work on supporting query strings.  This PR has the following changes:

1. Deterministic ordering for api entry insertion in the code generation logic
2. Moves all the argument processing into _processArgs which simplifies the sync and async makeApiCall functions, which means more shared code between async and sync
3. Adds support for building URLs and signed URLs for query-string params
4. Adds supprt for making api calls with query strings when _makeApiCall is called with appropriate arguments

Still to do:

1. Add tests for query-string handling
2. Change functionality of _processArgs to support query-string parameters in the call itself
3. Figure out why python 2.7 unit tests just plain don't work for me on my machine.  All development done with Python 3.6
4. Make sure that topic exchanges are also generated in a deterministic fashion 

Please ignore the changes to files other than taskcluster/client.py, taskcluster/async/asyncclient.py and genCode.py.

