### PR TITLE
Remove clock skew in temp credentials generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ temporary credentials as follows. Notice that the credentials cannot last more
 than 31 days, and you can only revoke them by revoking the credentials that was
 used to issue them (this takes up to one hour).
 
+It is not the responsibility of the caller to apply any clock drift adjustment
+to the start or expiry time - this is handled by the auth service directly.
+
 ```python
 import datetime
 

--- a/taskcluster/async/asyncclient.py
+++ b/taskcluster/async/asyncclient.py
@@ -279,6 +279,9 @@ def createApiClient(name, api):
 def createTemporaryCredentials(clientId, accessToken, start, expiry, scopes, name=None):
     """ Create a set of temporary credentials
 
+    Callers should not apply any clock skew; clock drift is accounted for by
+    auth service.
+
     clientId: the issuing clientId
     accessToken: the issuer's accessToken
     start: start time of credentials, seconds since epoch

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -615,6 +615,9 @@ def createApiClient(name, api):
 def createTemporaryCredentials(clientId, accessToken, start, expiry, scopes, name=None):
     """ Create a set of temporary credentials
 
+    Callers should not apply any clock skew; clock drift is accounted for by
+    auth service.
+
     clientId: the issuing clientId
     accessToken: the issuer's accessToken
     start: start time of credentials (datetime.datetime)

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -44,8 +44,8 @@ class TestAuthenticationAsync(base.TCTest):
                 tempCred = subjectAsync.createTemporaryCredentials(
                     'tester',
                     'no-secret',
-                    datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-                    datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+                    datetime.datetime.utcnow(),
+                    datetime.datetime.utcnow() + datetime.timedelta(hours=1),
                     ['test:xyz'],
                 )
                 client = subjectAsync.Auth({

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -754,8 +754,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:xyz'],
         )
         client = subject.Auth({
@@ -772,8 +772,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:xyz'],
             name='credName'
         )
@@ -791,8 +791,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:xyz:*'],
         )
         client = subject.Auth({
@@ -811,8 +811,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:xyz:*'],
             name='credName'
         )
@@ -863,8 +863,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:*'],
         )
         client = subject.Auth({
@@ -900,8 +900,8 @@ class TestAuthentication(base.TCTest):
         tempCred = subject.createTemporaryCredentials(
             'tester',
             'no-secret',
-            datetime.datetime.utcnow() - datetime.timedelta(hours=10),
-            datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            datetime.datetime.utcnow(),
+            datetime.datetime.utcnow() + datetime.timedelta(hours=1),
             ['test:*'],
         )
         client = subject.Auth({


### PR DESCRIPTION
This is now taken care of in the auth service directly:
https://github.com/taskcluster/taskcluster-auth/pull/117