### PR TITLE
Return None for Content-Length=0

### DIFF
--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -496,6 +496,11 @@ class BaseClient(object):
             if status == 204:
                 return None
 
+            # Handle content length 0 (empty server responses)
+            servresp = response.length
+            if servresp == 0:
+                return None
+            
             # Catch retryable errors and go to the beginning of the loop
             # to do the retry
             if 500 <= status and status < 600 and retry < retries:

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -497,7 +497,7 @@ class BaseClient(object):
                 return None
 
             # Handle content length 0 (empty server responses)
-            if header("Content-Length: ".filesize(response)) == 0:
+            if headers.get('Content-Length') == 0:
                 return None
             
             # Catch retryable errors and go to the beginning of the loop

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -497,8 +497,7 @@ class BaseClient(object):
                 return None
 
             # Handle content length 0 (empty server responses)
-            servresp = response.length
-            if servresp == 0:
+            if header("Content-Length: ".filesize(response)) == 0:
                 return None
             
             # Catch retryable errors and go to the beginning of the loop


### PR DESCRIPTION
Checked the response length using the Content-Length header and status code and return None if it is 0. This is to resolve empty server responses.