### PR TITLE
Remove encrypted envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests>=2.4.3,<3',
     'mohawk>=0.3.4,<0.4',
     'slugid>=1.0.7,<2',
-    'six>=1.10.0,<1.11',
+    'six>=1.10.0,<2',
 ]
 
 # from http://testrun.org/tox/latest/example/basic.html

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ tests_require = [
     'flake8==2.5.0',
     'psutil==2.1.3',
     'hypothesis==3.6.1',
-    'pgpy>=0.4.0,<0.5',
     'tox==2.3.2',
     'coverage==4.1b2',
     'python-dateutil==2.6.0',

--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -24,13 +24,6 @@ MAX_DELAY = 30
 
 log = logging.getLogger(__name__)
 
-try:
-    # Do not require pgpy for all tasks
-    import pgpy
-except ImportError:
-    pgpy = None
-    log.debug("Encryption disabled. Install pgpy to enable.")
-
 # Regular expression matching: X days Y hours Z minutes
 # todo: support hr, wk, yr
 r = re.compile(''.join([
@@ -310,67 +303,12 @@ def putFile(filename, url, contentType):
         })
 
 
-def _messageForEncryptedEnvVar(taskId, startTime, endTime, name, value):
-    return {
-        "messageVersion": "1",
-        "taskId": taskId,
-        "startTime": startTime,
-        "endTime": endTime,
-        "name": name,
-        "value": value
-    }
-
-
 def encryptEnvVar(taskId, startTime, endTime, name, value, keyFile):
-    message = toStr(json.dumps(_messageForEncryptedEnvVar(
-        taskId, startTime, endTime, name, value)))
-    return base64.b64encode(_encrypt(message, keyFile))
-
-
-def _encrypt(message, keyFile):
-    """Encrypt and base64 encode message.
-
-    :type message: str or unicode
-    :type keyFile: str or unicode
-    :return: base64 representation of binary (unarmoured) encrypted message
-    """
-    if not pgpy:
-        raise RuntimeError("Install `pgpy' to use encryption")
-    key, _ = pgpy.PGPKey.from_file(keyFile)
-    msg = pgpy.PGPMessage.new(message)
-    encrypted = key.encrypt(msg)
-    if six.PY2:
-        encrypted_bytes = encrypted.__bytes__()
-    else:
-        encrypted_bytes = bytes(encrypted)
-    return encrypted_bytes
+    raise Exception("Encrypted environment variables are no longer supported")
 
 
 def decryptMessage(message, privateKey):
-    """Decrypt base64-encoded message
-    :param message: base64-encode message
-    :param privateKey: path to private key
-    :return: decrypted message dictionary
-    """
-    decodedMessage = base64.b64decode(message)
-    return json.loads(_decrypt(decodedMessage, privateKey))
-
-
-def _decrypt(blob, privateKey):
-    """
-    :param blob: encrypted binary string
-    :param privateKey: path to private key
-    :return: decrypted text
-
-    """
-    if not pgpy:
-        raise RuntimeError("Install `pgpy' to use encryption")
-    key, _ = pgpy.PGPKey.from_file(privateKey)
-    msg = pgpy.PGPMessage()
-    msg.parse(blob)
-    decrypted = key.decrypt(msg)
-    message = decrypted.message
-    return message
+    raise Exception("Decryption is no longer supported")
 
 
 def isExpired(certificate):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,6 @@ import taskcluster.utils as subject
 import dateutil.parser
 import httmock
 import mock
-import os
 import requests
 
 import base
@@ -199,65 +198,6 @@ class TestStableSlugIdClosure(TestCase):
         s1 = subject.stableSlugId()
         s2 = subject.stableSlugId()
         self.assertNotEqual(s1(text), s2(text))
-
-
-class TestEncryptEnvVarMessage(TestCase):
-
-    @given(st.text(), st.one_of(st.floats(), st.integers()),
-           st.one_of(st.floats(), st.integers()), st.text(), st.text())
-    def test_message_format(self, taskId, startTime, endTime, name, value):
-        expected = {
-            "messageVersion": "1",
-            "taskId": taskId,
-            "startTime": startTime,
-            "endTime": endTime,
-            "name": name,
-            "value": value
-        }
-        self.assertDictEqual(expected, subject._messageForEncryptedEnvVar(
-            taskId, startTime, endTime, name, value))
-
-
-class TestEncrypt(TestCase):
-
-    @given(st.text(), st.one_of(st.floats(), st.integers()),
-           st.one_of(st.floats(), st.integers()), st.text(), st.text())
-    def test_generic(self, taskId, startTime, endTime, name, value):
-        key_file = os.path.join(os.path.dirname(__file__), "public.key")
-
-        self.assertTrue(subject.encryptEnvVar(taskId, startTime, endTime, name,
-                                              value, key_file).startswith(b"wcB"),
-                        "Encrypted string should always start with 'wcB'")
-
-
-class TestDecrypt(TestCase):
-
-    def test_encrypt_text(self):
-        privateKey = os.path.join(os.path.dirname(__file__), "secret.key")
-        publicKey = os.path.join(os.path.dirname(__file__), "public.key")
-        text = "Hello \U0001F4A9!"
-        encrypted = subject._encrypt(text, publicKey)
-        self.assertNotEqual(text, encrypted)
-        decrypted = subject._decrypt(encrypted, privateKey)
-        self.assertEqual(text, decrypted)
-
-
-class TestDecryptMessage(TestCase):
-
-    def test_decryptMessage(self):
-        privateKey = os.path.join(os.path.dirname(__file__), "secret.key")
-        publicKey = os.path.join(os.path.dirname(__file__), "public.key")
-        expected = {
-            "messageVersion": "1",
-            "taskId": "abcd",
-            "startTime": 1,
-            "endTime": 2,
-            "name": "Name",
-            "value": "Value"
-        }
-        encrypted = subject.encryptEnvVar("abcd", 1, 2, "Name", "Value", publicKey)
-        decrypted = subject.decryptMessage(encrypted, privateKey)
-        self.assertDictEqual(expected, decrypted)
 
 
 class TestFromNow(TestCase):


### PR DESCRIPTION
This also updates to the latest version of Six.  I can't run the py3.5 tests on this laptop, so let's make sure that travis passes.

@escapewindow once this merges, we should be able to do major version release.

cc @rail & @mozbhearsum for encrypted environment var support, note that this will be a major version bump

cc @edmorley, even though I know you're no longer following this client library, we're doing it :)