### PR TITLE
Pinning async_timeout<3 breaks aiohttp3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ elif sys.version_info[:2] < (3, 5):
 elif sys.version_info[:2] >= (3, 5):
     install_requires.extend([
         'aiohttp>=2.0.0,<4',
-        'async_timeout>=2.0.0,<3',
+        'async_timeout>=2.0.0,<4',
     ])
 
 if __name__ == '__main__':


### PR DESCRIPTION
aiohttp 3 requires `async_timeout>=3,<4`

@jhford  This blocks scriptworker's [aiohttp 3 rollout](https://github.com/mozilla-releng/scriptworker/pull/200) which has been a long time coming; can we get a release shipped with this fix quickly?