### PR TITLE
url encoding doesn't work in async

### DIFF
--- a/taskcluster/async/asyncutils.py
+++ b/taskcluster/async/asyncutils.py
@@ -89,6 +89,9 @@ async def makeSingleHttpRequest(method, url, payload, headers, session=None):
     skip_auto_headers = [aiohttp.hdrs.CONTENT_TYPE]
 
     try:
+        # https://docs.aiohttp.org/en/stable/client_quickstart.html#passing-parameters-in-urls
+        # we must avoid aiohttp's helpful "requoting" functionality, as it breaks Hawk signatures
+        url = aiohttp.client.URL(url, encoded=True)
         async with session.request(
             method, url, data=payload, headers=headers,
             skip_auto_headers=skip_auto_headers, compress=False


### PR DESCRIPTION
This fails with `bad Mac`.  Changing `/` to `%2F` works.

```python
from taskcluster.async import Auth
import asyncio

async def fn():
    auth = Auth()
    await auth.deleteRole('hook-id:project-gecko/in-tree-action-1-purge-caches/b17ba2d183')

loop = asyncio.get_event_loop()
loop.run_until_complete(fn())
loop.close()
```

However, this works fine without any manual encoding:

```python
from taskcluster import Auth

auth = Auth()
auth.deleteRole('hook-id:project-gecko/in-tree-action-1-purge-caches/b17ba2d183')
```