### PR TITLE
Remove use of baseUrl

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -831,6 +831,7 @@
         }
       ],
       "name": "aws-provisioner",
+      "serviceName": "aws-provisioner",
       "title": "AWS Provisioner API Documentation",
       "version": 0
     },
@@ -943,10 +944,21 @@
       "entries": [
         {
           "args": [],
+          "description": "Respond without doing anything.\nThis endpoint is used to check that the service is up.",
+          "method": "get",
+          "name": "ping",
+          "query": [],
+          "route": "/ping",
+          "stability": "stable",
+          "title": "Ping Server",
+          "type": "function"
+        },
+        {
+          "args": [],
           "description": "This method is only for debugging the ec2-manager",
           "method": "get",
           "name": "listWorkerTypes",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#",
+          "output": "v1/list-worker-types.json#",
           "query": [],
           "route": "/worker-types",
           "stability": "experimental",
@@ -958,16 +970,12 @@
             "workerType"
           ],
           "description": "Request an instance of a worker type",
-          "input": "http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#",
+          "input": "v1/run-instance-request.json#",
           "method": "put",
           "name": "runInstance",
           "query": [],
           "route": "/worker-types/<workerType>/instance",
-          "scopes": [
-            [
-              "ec2-manager:manage-resources:<workerType>"
-            ]
-          ],
+          "scopes": "ec2-manager:manage-resources:<workerType>",
           "stability": "experimental",
           "title": "Run an instance",
           "type": "function"
@@ -981,11 +989,7 @@
           "name": "terminateWorkerType",
           "query": [],
           "route": "/worker-types/<workerType>/resources",
-          "scopes": [
-            [
-              "ec2-manager:manage-resources:<workerType>"
-            ]
-          ],
+          "scopes": "ec2-manager:manage-resources:<workerType>",
           "stability": "experimental",
           "title": "Terminate all resources from a worker type",
           "type": "function"
@@ -997,7 +1001,7 @@
           "description": "Return an object which has a generic state description. This only contains counts of instances",
           "method": "get",
           "name": "workerTypeStats",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#",
+          "output": "v1/worker-type-resources.json#",
           "query": [],
           "route": "/worker-types/<workerType>/stats",
           "stability": "experimental",
@@ -1011,7 +1015,7 @@
           "description": "Return a view of the health of a given worker type",
           "method": "get",
           "name": "workerTypeHealth",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/health.json#",
+          "output": "v1/health.json#",
           "query": [],
           "route": "/worker-types/<workerType>/health",
           "stability": "experimental",
@@ -1025,7 +1029,7 @@
           "description": "Return a list of the most recent errors encountered by a worker type",
           "method": "get",
           "name": "workerTypeErrors",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/errors.json#",
+          "output": "v1/errors.json#",
           "query": [],
           "route": "/worker-types/<workerType>/errors",
           "stability": "experimental",
@@ -1039,7 +1043,7 @@
           "description": "Return state information for a given worker type",
           "method": "get",
           "name": "workerTypeState",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/worker-type-state.json#",
+          "output": "v1/worker-type-state.json#",
           "query": [],
           "route": "/worker-types/<workerType>/state",
           "stability": "experimental",
@@ -1051,16 +1055,12 @@
             "name"
           ],
           "description": "Idempotently ensure that a keypair of a given name exists",
-          "input": "http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#",
+          "input": "v1/create-key-pair.json#",
           "method": "get",
           "name": "ensureKeyPair",
           "query": [],
           "route": "/key-pairs/<name>",
-          "scopes": [
-            [
-              "ec2-manager:manage-key-pairs:<name>"
-            ]
-          ],
+          "scopes": "ec2-manager:manage-key-pairs:<name>",
           "stability": "experimental",
           "title": "Ensure a KeyPair for a given worker type exists",
           "type": "function"
@@ -1074,11 +1074,7 @@
           "name": "removeKeyPair",
           "query": [],
           "route": "/key-pairs/<name>",
-          "scopes": [
-            [
-              "ec2-manager:manage-key-pairs:<name>"
-            ]
-          ],
+          "scopes": "ec2-manager:manage-key-pairs:<name>",
           "stability": "experimental",
           "title": "Ensure a KeyPair for a given worker type does not exist",
           "type": "function"
@@ -1093,14 +1089,15 @@
           "name": "terminateInstance",
           "query": [],
           "route": "/region/<region>/instance/<instanceId>",
-          "scopes": [
-            [
-              "ec2-manager:manage-instances:<region>:<instanceId>"
-            ],
-            [
-              "ec2-manager:manage-resources:<workerType>"
+          "scopes": {
+            "AnyOf": [
+              "ec2-manager:manage-instances:<region>:<instanceId>",
+              {
+                "if": "hasWorkerType",
+                "then": "ec2-manager:manage-resources:<workerType>"
+              }
             ]
-          ],
+          },
           "stability": "experimental",
           "title": "Terminate an instance",
           "type": "function"
@@ -1110,7 +1107,7 @@
           "description": "Return a list of possible prices for EC2",
           "method": "get",
           "name": "getPrices",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/prices.json#",
+          "output": "v1/prices.json#",
           "query": [],
           "route": "/prices",
           "stability": "experimental",
@@ -1120,10 +1117,10 @@
         {
           "args": [],
           "description": "Return a list of possible prices for EC2",
-          "input": "http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#",
+          "input": "v1/prices-request.json#",
           "method": "post",
           "name": "getSpecificPrices",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/prices.json#",
+          "output": "v1/prices.json#",
           "query": [],
           "route": "/prices",
           "stability": "experimental",
@@ -1135,7 +1132,7 @@
           "description": "Give some basic stats on the health of our EC2 account",
           "method": "get",
           "name": "getHealth",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/health.json#",
+          "output": "v1/health.json#",
           "query": [],
           "route": "/health",
           "stability": "experimental",
@@ -1147,7 +1144,7 @@
           "description": "Return a list of recent errors encountered",
           "method": "get",
           "name": "getRecentErrors",
-          "output": "http://schemas.taskcluster.net/ec2-manager/v1/errors.json#",
+          "output": "v1/errors.json#",
           "query": [],
           "route": "/errors",
           "stability": "experimental",
@@ -1161,11 +1158,7 @@
           "name": "regions",
           "query": [],
           "route": "/internal/regions",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "See the list of regions managed by this ec2-manager",
           "type": "function"
@@ -1177,11 +1170,7 @@
           "name": "amiUsage",
           "query": [],
           "route": "/internal/ami-usage",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "See the list of AMIs and their usage",
           "type": "function"
@@ -1193,11 +1182,7 @@
           "name": "ebsUsage",
           "query": [],
           "route": "/internal/ebs-usage",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "See the current EBS volume usage list",
           "type": "function"
@@ -1209,11 +1194,7 @@
           "name": "dbpoolStats",
           "query": [],
           "route": "/internal/db-pool-stats",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "Statistics on the Database client pool",
           "type": "function"
@@ -1225,11 +1206,7 @@
           "name": "allState",
           "query": [],
           "route": "/internal/all-state",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "List out the entire internal state",
           "type": "function"
@@ -1241,11 +1218,7 @@
           "name": "sqsStats",
           "query": [],
           "route": "/internal/sqs-stats",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "Statistics on the sqs queues",
           "type": "function"
@@ -1257,38 +1230,13 @@
           "name": "purgeQueues",
           "query": [],
           "route": "/internal/purge-queues",
-          "scopes": [
-            [
-              "ec2-manager:internals"
-            ]
-          ],
+          "scopes": "ec2-manager:internals",
           "stability": "experimental",
           "title": "Purge the SQS queues",
           "type": "function"
-        },
-        {
-          "args": [],
-          "description": "Generate an API reference for this service",
-          "method": "get",
-          "name": "apiReference",
-          "query": [],
-          "route": "/internal/api-reference",
-          "stability": "experimental",
-          "title": "API Reference",
-          "type": "function"
-        },
-        {
-          "args": [],
-          "description": "Respond without doing anything.\nThis endpoint is used to check that the service is up.",
-          "method": "get",
-          "name": "ping",
-          "query": [],
-          "route": "/ping",
-          "stability": "stable",
-          "title": "Ping Server",
-          "type": "function"
         }
       ],
+      "serviceName": "ec2-manager",
       "title": "EC2 Instance Manager",
       "version": 0
     },
@@ -1536,7 +1484,7 @@
     "reference": {
       "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
       "baseUrl": "https://hooks.taskcluster.net/v1/",
-      "description": "Hooks are a mechanism for creating tasks in response to events.\n\nHooks are identified with a `hookGroupId` and a `hookId`.\n\nWhen an event occurs, the resulting task is automatically created.  The\ntask is created using the scope `assume:hook-id:<hookGroupId>/<hookId>`,\nwhich must have scopes to make the createTask call, including satisfying all\nscopes in `task.scopes`.  The new task has a `taskGroupId` equal to its\n`taskId`, as is the convention for decision tasks.\n\nHooks can have a \"schedule\" indicating specific times that new tasks should\nbe created.  Each schedule is in a simple cron format, per \nhttps://www.npmjs.com/package/cron-parser.  For example:\n * `['0 0 1 * * *']` -- daily at 1:00 UTC\n * `['0 0 9,21 * * 1-5', '0 0 12 * * 0,6']` -- weekdays at 9:00 and 21:00 UTC, weekends at noon\n\nThe task definition is used as a JSON-e template, with a context depending on how it is fired.  See\nhttps://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks\nfor more information.",
+      "description": "Hooks are a mechanism for creating tasks in response to events.\n\nHooks are identified with a `hookGroupId` and a `hookId`.\n\nWhen an event occurs, the resulting task is automatically created.  The\ntask is created using the scope `assume:hook-id:<hookGroupId>/<hookId>`,\nwhich must have scopes to make the createTask call, including satisfying all\nscopes in `task.scopes`.  The new task has a `taskGroupId` equal to its\n`taskId`, as is the convention for decision tasks.\n\nHooks can have a \"schedule\" indicating specific times that new tasks should\nbe created.  Each schedule is in a simple cron format, per \nhttps://www.npmjs.com/package/cron-parser.  For example:\n * `['0 0 1 * * *']` -- daily at 1:00 UTC\n * `['0 0 9,21 * * 1-5', '0 0 12 * * 0,6']` -- weekdays at 9:00 and 21:00 UTC, weekends at noon\n\nThe task definition is used as a JSON-e template, with a context depending on how it is fired.  See\n[/docs/reference/core/taskcluster-hooks/docs/firing-hooks](firing-hooks)\nfor more information.",
       "entries": [
         {
           "args": [],
@@ -1850,20 +1798,6 @@
       "description": "The Login service serves as the interface between external authentication\nsystems and Taskcluster credentials.",
       "entries": [
         {
-          "args": [
-            "provider"
-          ],
-          "description": "Given an OIDC `access_token` from a trusted OpenID provider, return a\nset of Taskcluster credentials for use on behalf of the identified\nuser.\n\nThis method is typically not called with a Taskcluster client library\nand does not accept Hawk credentials. The `access_token` should be\ngiven in an `Authorization` header:\n```\nAuthorization: Bearer abc.xyz\n```\n\nThe `access_token` is first verified against the named\n:provider, then passed to the provider's API to retrieve a user\nprofile. That profile is then used to generate Taskcluster credentials\nappropriate to the user. Note that the resulting credentials may or may\nnot include a `certificate` property. Callers should be prepared for either\nalternative.\n\nThe given credentials will expire in a relatively short time. Callers should\nmonitor this expiration and refresh the credentials if necessary, by calling\nthis endpoint again, if they have expired.",
-          "method": "get",
-          "name": "oidcCredentials",
-          "output": "http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json",
-          "query": [],
-          "route": "/oidc-credentials/<provider>",
-          "stability": "experimental",
-          "title": "Get Taskcluster credentials given a suitable `access_token`",
-          "type": "function"
-        },
-        {
           "args": [],
           "description": "Respond without doing anything.\nThis endpoint is used to check that the service is up.",
           "method": "get",
@@ -1873,9 +1807,23 @@
           "stability": "stable",
           "title": "Ping Server",
           "type": "function"
+        },
+        {
+          "args": [
+            "provider"
+          ],
+          "description": "Given an OIDC `access_token` from a trusted OpenID provider, return a\nset of Taskcluster credentials for use on behalf of the identified\nuser.\n\nThis method is typically not called with a Taskcluster client library\nand does not accept Hawk credentials. The `access_token` should be\ngiven in an `Authorization` header:\n```\nAuthorization: Bearer abc.xyz\n```\n\nThe `access_token` is first verified against the named\n:provider, then passed to the provider's APIBuilder to retrieve a user\nprofile. That profile is then used to generate Taskcluster credentials\nappropriate to the user. Note that the resulting credentials may or may\nnot include a `certificate` property. Callers should be prepared for either\nalternative.\n\nThe given credentials will expire in a relatively short time. Callers should\nmonitor this expiration and refresh the credentials if necessary, by calling\nthis endpoint again, if they have expired.",
+          "method": "get",
+          "name": "oidcCredentials",
+          "output": "v1/oidc-credentials-response.json#",
+          "query": [],
+          "route": "/oidc-credentials/<provider>",
+          "stability": "experimental",
+          "title": "Get Taskcluster credentials given a suitable `access_token`",
+          "type": "function"
         }
       ],
-      "name": "login",
+      "serviceName": "login",
       "title": "Login API",
       "version": 0
     },
@@ -1947,6 +1895,79 @@
       "version": 0
     },
     "referenceUrl": "https://references.taskcluster.net/notify/v1/api.json"
+  },
+  "Pulse": {
+    "reference": {
+      "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
+      "baseUrl": "https://pulse.taskcluster.net/v1/",
+      "description": "The taskcluster-pulse service, typically available at `pulse.taskcluster.net`\nmanages pulse credentials for taskcluster users.\n\nA service to manage Pulse credentials for anything using\nTaskcluster credentials. This allows for self-service pulse\naccess and greater control within the Taskcluster project.",
+      "entries": [
+        {
+          "args": [],
+          "description": "Respond without doing anything.\nThis endpoint is used to check that the service is up.",
+          "method": "get",
+          "name": "ping",
+          "query": [],
+          "route": "/ping",
+          "stability": "stable",
+          "title": "Ping Server",
+          "type": "function"
+        },
+        {
+          "args": [],
+          "description": "List the namespaces managed by this service.\n\nThis will list up to 1000 namespaces. If more namespaces are present a\n`continuationToken` will be returned, which can be given in the next\nrequest. For the initial request, do not provide continuation token.",
+          "method": "get",
+          "name": "listNamespaces",
+          "output": "v1/list-namespaces-response.json#",
+          "query": [
+            "limit",
+            "continuationToken"
+          ],
+          "route": "/namespaces",
+          "stability": "experimental",
+          "title": "List Namespaces",
+          "type": "function"
+        },
+        {
+          "args": [
+            "namespace"
+          ],
+          "description": "Get public information about a single namespace. This is the same information\nas returned by `listNamespaces`.",
+          "method": "get",
+          "name": "namespace",
+          "output": "v1/namespace.json#",
+          "query": [],
+          "route": "/namespace/<namespace>",
+          "stability": "experimental",
+          "title": "Get a namespace",
+          "type": "function"
+        },
+        {
+          "args": [
+            "namespace"
+          ],
+          "description": "Claim a namespace, returning a connection string with access to that namespace\ngood for use until the `reclaimAt` time in the response body. The connection\nstring can be used as many times as desired during this period, but must not\nbe used after `reclaimAt`.\n\nConnections made with this connection string may persist beyond `reclaimAt`,\nalthough it should not persist forever.  24 hours is a good maximum, and this\nservice will terminate connections after 72 hours (although this value is\nconfigurable).\n\nThe specified `expires` time updates any existing expiration times.  Connections\nfor expired namespaces will be terminated.",
+          "input": "v1/namespace-request.json#",
+          "method": "post",
+          "name": "claimNamespace",
+          "output": "v1/namespace-response.json#",
+          "query": [],
+          "route": "/namespace/<namespace>",
+          "scopes": {
+            "AllOf": [
+              "pulse:namespace:<namespace>"
+            ]
+          },
+          "stability": "experimental",
+          "title": "Claim a namespace",
+          "type": "function"
+        }
+      ],
+      "serviceName": "pulse",
+      "title": "Pulse Management Service",
+      "version": 0
+    },
+    "referenceUrl": "https://references.taskcluster.net/pulse/v1/api.json"
   },
   "PurgeCache": {
     "reference": {
@@ -3510,15 +3531,16 @@
               "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
             }
           ],
-          "schema": "http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#",
+          "schema": "v1/pulse-job.json#",
           "title": "Job Messages",
           "type": "topic-exchange"
         }
       ],
       "exchangePrefix": "exchange/taskcluster-treeherder/v1/",
+      "serviceName": "treeherder",
       "title": "Taskcluster-treeherder Pulse Exchange",
       "version": 0
     },
-    "referenceUrl": "https://references.taskcluster.net/taskcluster-treeherder/v1/exchanges.json"
+    "referenceUrl": "https://references.taskcluster.net/treeherder/v1/exchanges.json"
   }
 }

--- a/genCode.py
+++ b/genCode.py
@@ -77,12 +77,22 @@ def createStaticClient(name, api, genAsync=False):
 
     lines.append('    classOptions = {')
 
-    copiedOptions = ('baseUrl', 'exchangePrefix')
+    # apply a default for apiVersion; this can be removed when all services have
+    # been upgraded to provide apiVersion
+    if 'apiVersion' not in api:
+        api['apiVersion'] = 'v1'
+
+    copiedOptions = ('exchangePrefix',)
     for opt in copiedOptions:
         if api.get(opt):
-            lines.append('        "%s": "%s"' % (opt, api[opt]))
+            lines.append('        "%s": "%s",' % (opt, api[opt]))
+    lines.append('    }')
 
-    lines.extend(['    }', ''])
+    copiedProperties = ('serviceName', 'apiVersion')
+    for opt in copiedProperties:
+        if api.get(opt):
+            lines.append('    %s = %s' % (opt, repr(api[opt])))
+    lines.append('')
 
     # We need to build up some information about how the functions work
     functionInfo = {}

--- a/taskcluster/_client_importer.py
+++ b/taskcluster/_client_importer.py
@@ -9,6 +9,7 @@ from .hooks import Hooks  # NOQA
 from .index import Index  # NOQA
 from .login import Login  # NOQA
 from .notify import Notify  # NOQA
+from .pulse import Pulse  # NOQA
 from .purgecache import PurgeCache  # NOQA
 from .purgecacheevents import PurgeCacheEvents  # NOQA
 from .queue import Queue  # NOQA

--- a/taskcluster/aio/_client_importer.py
+++ b/taskcluster/aio/_client_importer.py
@@ -9,6 +9,7 @@ from .hooks import Hooks  # NOQA
 from .index import Index  # NOQA
 from .login import Login  # NOQA
 from .notify import Notify  # NOQA
+from .pulse import Pulse  # NOQA
 from .purgecache import PurgeCache  # NOQA
 from .purgecacheevents import PurgeCacheEvents  # NOQA
 from .queue import Queue  # NOQA

--- a/taskcluster/aio/asyncclient.py
+++ b/taskcluster/aio/asyncclient.py
@@ -114,7 +114,7 @@ class AsyncBaseClient(BaseClient):
         the logic about doing failure retry and passes off the actual work
         of doing an HTTP request to another method."""
 
-        url = self._joinBaseUrlAndRoute(route)
+        url = self._constructUrl(route)
         log.debug('Full URL used is: %s', url)
 
         hawkExt = self.makeHawkExt()
@@ -239,6 +239,8 @@ class AsyncBaseClient(BaseClient):
 
 
 def createApiClient(name, api):
+    api = api['reference']
+
     attributes = dict(
         name=name,
         __doc__=api.get('description'),
@@ -246,12 +248,22 @@ def createApiClient(name, api):
         funcinfo={},
     )
 
-    copiedOptions = ('baseUrl', 'exchangePrefix')
-    for opt in copiedOptions:
-        if opt in api['reference']:
-            attributes['classOptions'][opt] = api['reference'][opt]
+    # apply a default for apiVersion; this can be removed when all services
+    # have apiVersion
+    if 'apiVersion' not in api:
+        api['apiVersion'] = 'v1'
 
-    for entry in api['reference']['entries']:
+    copiedOptions = ('exchangePrefix',)
+    for opt in copiedOptions:
+        if opt in api:
+            attributes['classOptions'][opt] = api[opt]
+
+    copiedProperties = ('serviceName', 'apiVersion')
+    for opt in copiedProperties:
+        if opt in api:
+            attributes[opt] = api[opt]
+
+    for entry in api['entries']:
         if entry['type'] == 'function':
             def addApiCall(e):
                 async def apiCall(self, *args, **kwargs):

--- a/taskcluster/aio/auth.py
+++ b/taskcluster/aio/auth.py
@@ -55,8 +55,9 @@ class Auth(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://auth.taskcluster.net/v1/"
     }
+    serviceName = 'auth'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/authevents.py
+++ b/taskcluster/aio/authevents.py
@@ -24,8 +24,10 @@ class AuthEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-auth/v1/"
+        "exchangePrefix": "exchange/taskcluster-auth/v1/",
     }
+    serviceName = 'auth'
+    apiVersion = 'v1'
 
     def clientCreated(self, *args, **kwargs):
         """

--- a/taskcluster/aio/awsprovisioner.py
+++ b/taskcluster/aio/awsprovisioner.py
@@ -44,8 +44,9 @@ class AwsProvisioner(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://aws-provisioner.taskcluster.net/v1"
     }
+    serviceName = 'aws-provisioner'
+    apiVersion = 'v1'
 
     async def listWorkerTypeSummaries(self, *args, **kwargs):
         """

--- a/taskcluster/aio/awsprovisionerevents.py
+++ b/taskcluster/aio/awsprovisionerevents.py
@@ -17,8 +17,9 @@ class AwsProvisionerEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/"
+        "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/",
     }
+    apiVersion = 'v1'
 
     def workerTypeCreated(self, *args, **kwargs):
         """

--- a/taskcluster/aio/ec2manager.py
+++ b/taskcluster/aio/ec2manager.py
@@ -17,8 +17,21 @@ class EC2Manager(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://ec2-manager.taskcluster.net/v1"
     }
+    serviceName = 'ec2-manager'
+    apiVersion = 'v1'
+
+    async def ping(self, *args, **kwargs):
+        """
+        Ping Server
+
+        Respond without doing anything.
+        This endpoint is used to check that the service is up.
+
+        This method is ``stable``
+        """
+
+        return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     async def listWorkerTypes(self, *args, **kwargs):
         """
@@ -26,7 +39,7 @@ class EC2Manager(AsyncBaseClient):
 
         This method is only for debugging the ec2-manager
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#``
+        This method gives output: ``v1/list-worker-types.json#``
 
         This method is ``experimental``
         """
@@ -39,7 +52,7 @@ class EC2Manager(AsyncBaseClient):
 
         Request an instance of a worker type
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#``
+        This method takes input: ``v1/run-instance-request.json#``
 
         This method is ``experimental``
         """
@@ -63,7 +76,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return an object which has a generic state description. This only contains counts of instances
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#``
+        This method gives output: ``v1/worker-type-resources.json#``
 
         This method is ``experimental``
         """
@@ -76,7 +89,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return a view of the health of a given worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/health.json#``
+        This method gives output: ``v1/health.json#``
 
         This method is ``experimental``
         """
@@ -89,7 +102,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return a list of the most recent errors encountered by a worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/errors.json#``
+        This method gives output: ``v1/errors.json#``
 
         This method is ``experimental``
         """
@@ -102,7 +115,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return state information for a given worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/worker-type-state.json#``
+        This method gives output: ``v1/worker-type-state.json#``
 
         This method is ``experimental``
         """
@@ -115,7 +128,7 @@ class EC2Manager(AsyncBaseClient):
 
         Idempotently ensure that a keypair of a given name exists
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#``
+        This method takes input: ``v1/create-key-pair.json#``
 
         This method is ``experimental``
         """
@@ -150,7 +163,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return a list of possible prices for EC2
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/prices.json#``
+        This method gives output: ``v1/prices.json#``
 
         This method is ``experimental``
         """
@@ -163,9 +176,9 @@ class EC2Manager(AsyncBaseClient):
 
         Return a list of possible prices for EC2
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#``
+        This method takes input: ``v1/prices-request.json#``
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/prices.json#``
+        This method gives output: ``v1/prices.json#``
 
         This method is ``experimental``
         """
@@ -178,7 +191,7 @@ class EC2Manager(AsyncBaseClient):
 
         Give some basic stats on the health of our EC2 account
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/health.json#``
+        This method gives output: ``v1/health.json#``
 
         This method is ``experimental``
         """
@@ -191,7 +204,7 @@ class EC2Manager(AsyncBaseClient):
 
         Return a list of recent errors encountered
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/errors.json#``
+        This method gives output: ``v1/errors.json#``
 
         This method is ``experimental``
         """
@@ -289,29 +302,6 @@ class EC2Manager(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["purgeQueues"], *args, **kwargs)
 
-    async def apiReference(self, *args, **kwargs):
-        """
-        API Reference
-
-        Generate an API reference for this service
-
-        This method is ``experimental``
-        """
-
-        return await self._makeApiCall(self.funcinfo["apiReference"], *args, **kwargs)
-
-    async def ping(self, *args, **kwargs):
-        """
-        Ping Server
-
-        Respond without doing anything.
-        This endpoint is used to check that the service is up.
-
-        This method is ``stable``
-        """
-
-        return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
-
     funcinfo = {
         "allState": {
             'args': [],
@@ -325,13 +315,6 @@ class EC2Manager(AsyncBaseClient):
             'method': 'get',
             'name': 'amiUsage',
             'route': '/internal/ami-usage',
-            'stability': 'experimental',
-        },
-        "apiReference": {
-            'args': [],
-            'method': 'get',
-            'name': 'apiReference',
-            'route': '/internal/api-reference',
             'stability': 'experimental',
         },
         "dbpoolStats": {
@@ -350,7 +333,7 @@ class EC2Manager(AsyncBaseClient):
         },
         "ensureKeyPair": {
             'args': ['name'],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#',
+            'input': 'v1/create-key-pair.json#',
             'method': 'get',
             'name': 'ensureKeyPair',
             'route': '/key-pairs/<name>',
@@ -360,7 +343,7 @@ class EC2Manager(AsyncBaseClient):
             'args': [],
             'method': 'get',
             'name': 'getHealth',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/health.json#',
+            'output': 'v1/health.json#',
             'route': '/health',
             'stability': 'experimental',
         },
@@ -368,7 +351,7 @@ class EC2Manager(AsyncBaseClient):
             'args': [],
             'method': 'get',
             'name': 'getPrices',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/prices.json#',
+            'output': 'v1/prices.json#',
             'route': '/prices',
             'stability': 'experimental',
         },
@@ -376,16 +359,16 @@ class EC2Manager(AsyncBaseClient):
             'args': [],
             'method': 'get',
             'name': 'getRecentErrors',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/errors.json#',
+            'output': 'v1/errors.json#',
             'route': '/errors',
             'stability': 'experimental',
         },
         "getSpecificPrices": {
             'args': [],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#',
+            'input': 'v1/prices-request.json#',
             'method': 'post',
             'name': 'getSpecificPrices',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/prices.json#',
+            'output': 'v1/prices.json#',
             'route': '/prices',
             'stability': 'experimental',
         },
@@ -393,7 +376,7 @@ class EC2Manager(AsyncBaseClient):
             'args': [],
             'method': 'get',
             'name': 'listWorkerTypes',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#',
+            'output': 'v1/list-worker-types.json#',
             'route': '/worker-types',
             'stability': 'experimental',
         },
@@ -427,7 +410,7 @@ class EC2Manager(AsyncBaseClient):
         },
         "runInstance": {
             'args': ['workerType'],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#',
+            'input': 'v1/run-instance-request.json#',
             'method': 'put',
             'name': 'runInstance',
             'route': '/worker-types/<workerType>/instance',
@@ -458,7 +441,7 @@ class EC2Manager(AsyncBaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeErrors',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/errors.json#',
+            'output': 'v1/errors.json#',
             'route': '/worker-types/<workerType>/errors',
             'stability': 'experimental',
         },
@@ -466,7 +449,7 @@ class EC2Manager(AsyncBaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeHealth',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/health.json#',
+            'output': 'v1/health.json#',
             'route': '/worker-types/<workerType>/health',
             'stability': 'experimental',
         },
@@ -474,7 +457,7 @@ class EC2Manager(AsyncBaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeState',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/worker-type-state.json#',
+            'output': 'v1/worker-type-state.json#',
             'route': '/worker-types/<workerType>/state',
             'stability': 'experimental',
         },
@@ -482,7 +465,7 @@ class EC2Manager(AsyncBaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeStats',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#',
+            'output': 'v1/worker-type-resources.json#',
             'route': '/worker-types/<workerType>/stats',
             'stability': 'experimental',
         },

--- a/taskcluster/aio/github.py
+++ b/taskcluster/aio/github.py
@@ -25,8 +25,9 @@ class Github(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://github.taskcluster.net/v1/"
     }
+    serviceName = 'github'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/githubevents.py
+++ b/taskcluster/aio/githubevents.py
@@ -22,8 +22,10 @@ class GithubEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-github/v1/"
+        "exchangePrefix": "exchange/taskcluster-github/v1/",
     }
+    serviceName = 'github'
+    apiVersion = 'v1'
 
     def pullRequest(self, *args, **kwargs):
         """

--- a/taskcluster/aio/hooks.py
+++ b/taskcluster/aio/hooks.py
@@ -30,13 +30,14 @@ class Hooks(AsyncBaseClient):
      * `['0 0 9,21 * * 1-5', '0 0 12 * * 0,6']` -- weekdays at 9:00 and 21:00 UTC, weekends at noon
 
     The task definition is used as a JSON-e template, with a context depending on how it is fired.  See
-    https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks
+    [/docs/reference/core/taskcluster-hooks/docs/firing-hooks](firing-hooks)
     for more information.
     """
 
     classOptions = {
-        "baseUrl": "https://hooks.taskcluster.net/v1/"
     }
+    serviceName = 'hooks'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/index.py
+++ b/taskcluster/aio/index.py
@@ -108,8 +108,9 @@ class Index(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://index.taskcluster.net/v1/"
     }
+    serviceName = 'index'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/login.py
+++ b/taskcluster/aio/login.py
@@ -18,8 +18,21 @@ class Login(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://login.taskcluster.net/v1"
     }
+    serviceName = 'login'
+    apiVersion = 'v1'
+
+    async def ping(self, *args, **kwargs):
+        """
+        Ping Server
+
+        Respond without doing anything.
+        This endpoint is used to check that the service is up.
+
+        This method is ``stable``
+        """
+
+        return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     async def oidcCredentials(self, *args, **kwargs):
         """
@@ -37,7 +50,7 @@ class Login(AsyncBaseClient):
         ```
 
         The `access_token` is first verified against the named
-        :provider, then passed to the provider's API to retrieve a user
+        :provider, then passed to the provider's APIBuilder to retrieve a user
         profile. That profile is then used to generate Taskcluster credentials
         appropriate to the user. Note that the resulting credentials may or may
         not include a `certificate` property. Callers should be prepared for either
@@ -47,31 +60,19 @@ class Login(AsyncBaseClient):
         monitor this expiration and refresh the credentials if necessary, by calling
         this endpoint again, if they have expired.
 
-        This method gives output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
+        This method gives output: ``v1/oidc-credentials-response.json#``
 
         This method is ``experimental``
         """
 
         return await self._makeApiCall(self.funcinfo["oidcCredentials"], *args, **kwargs)
 
-    async def ping(self, *args, **kwargs):
-        """
-        Ping Server
-
-        Respond without doing anything.
-        This endpoint is used to check that the service is up.
-
-        This method is ``stable``
-        """
-
-        return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
-
     funcinfo = {
         "oidcCredentials": {
             'args': ['provider'],
             'method': 'get',
             'name': 'oidcCredentials',
-            'output': 'http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json',
+            'output': 'v1/oidc-credentials-response.json#',
             'route': '/oidc-credentials/<provider>',
             'stability': 'experimental',
         },

--- a/taskcluster/aio/notify.py
+++ b/taskcluster/aio/notify.py
@@ -19,8 +19,9 @@ class Notify(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://notify.taskcluster.net/v1/"
     }
+    serviceName = 'notify'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/pulse.py
+++ b/taskcluster/aio/pulse.py
@@ -22,74 +22,9 @@ class Pulse(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://pulse.taskcluster.net/v1"
     }
-
-    async def overview(self, *args, **kwargs):
-        """
-        Rabbit Overview
-
-        Get an overview of the Rabbit cluster.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
-
-        This method is ``experimental``
-        """
-
-        return await self._makeApiCall(self.funcinfo["overview"], *args, **kwargs)
-
-    async def listNamespaces(self, *args, **kwargs):
-        """
-        List Namespaces
-
-        List the namespaces managed by this service.
-
-        This will list up to 1000 namespaces. If more namespaces are present a
-        `continuationToken` will be returned, which can be given in the next
-        request. For the initial request, do not provide continuation.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
-
-        This method is ``experimental``
-        """
-
-        return await self._makeApiCall(self.funcinfo["listNamespaces"], *args, **kwargs)
-
-    async def namespace(self, *args, **kwargs):
-        """
-        Get a namespace
-
-        Get public information about a single namespace. This is the same information
-        as returned by `listNamespaces`.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
-
-        This method is ``experimental``
-        """
-
-        return await self._makeApiCall(self.funcinfo["namespace"], *args, **kwargs)
-
-    async def claimNamespace(self, *args, **kwargs):
-        """
-        Claim a namespace
-
-        Claim a namespace, returning a username and password with access to that
-        namespace good for a short time.  Clients should call this endpoint again
-        at the re-claim time given in the response, as the password will be rotated
-        soon after that time.  The namespace will expire, and any associated queues
-        and exchanges will be deleted, at the given expiration time.
-
-        The `expires` and `contact` properties can be updated at any time in a reclaim
-        operation.
-
-        This method takes input: ``http://schemas.taskcluster.net/pulse/v1/namespace-request.json``
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
-
-        This method is ``experimental``
-        """
-
-        return await self._makeApiCall(self.funcinfo["claimNamespace"], *args, **kwargs)
+    serviceName = 'pulse'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """
@@ -103,13 +38,70 @@ class Pulse(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
+    async def listNamespaces(self, *args, **kwargs):
+        """
+        List Namespaces
+
+        List the namespaces managed by this service.
+
+        This will list up to 1000 namespaces. If more namespaces are present a
+        `continuationToken` will be returned, which can be given in the next
+        request. For the initial request, do not provide continuation token.
+
+        This method gives output: ``v1/list-namespaces-response.json#``
+
+        This method is ``experimental``
+        """
+
+        return await self._makeApiCall(self.funcinfo["listNamespaces"], *args, **kwargs)
+
+    async def namespace(self, *args, **kwargs):
+        """
+        Get a namespace
+
+        Get public information about a single namespace. This is the same information
+        as returned by `listNamespaces`.
+
+        This method gives output: ``v1/namespace.json#``
+
+        This method is ``experimental``
+        """
+
+        return await self._makeApiCall(self.funcinfo["namespace"], *args, **kwargs)
+
+    async def claimNamespace(self, *args, **kwargs):
+        """
+        Claim a namespace
+
+        Claim a namespace, returning a connection string with access to that namespace
+        good for use until the `reclaimAt` time in the response body. The connection
+        string can be used as many times as desired during this period, but must not
+        be used after `reclaimAt`.
+
+        Connections made with this connection string may persist beyond `reclaimAt`,
+        although it should not persist forever.  24 hours is a good maximum, and this
+        service will terminate connections after 72 hours (although this value is
+        configurable).
+
+        The specified `expires` time updates any existing expiration times.  Connections
+        for expired namespaces will be terminated.
+
+        This method takes input: ``v1/namespace-request.json#``
+
+        This method gives output: ``v1/namespace-response.json#``
+
+        This method is ``experimental``
+        """
+
+        return await self._makeApiCall(self.funcinfo["claimNamespace"], *args, **kwargs)
+
     funcinfo = {
         "claimNamespace": {
             'args': ['namespace'],
-            'input': 'http://schemas.taskcluster.net/pulse/v1/namespace-request.json',
+            'input': 'v1/namespace-request.json#',
             'method': 'post',
             'name': 'claimNamespace',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/namespace-response.json',
+            'output': 'v1/namespace-response.json#',
             'route': '/namespace/<namespace>',
             'stability': 'experimental',
         },
@@ -117,8 +109,8 @@ class Pulse(AsyncBaseClient):
             'args': [],
             'method': 'get',
             'name': 'listNamespaces',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json',
-            'query': ['limit', 'continuation'],
+            'output': 'v1/list-namespaces-response.json#',
+            'query': ['limit', 'continuationToken'],
             'route': '/namespaces',
             'stability': 'experimental',
         },
@@ -126,16 +118,8 @@ class Pulse(AsyncBaseClient):
             'args': ['namespace'],
             'method': 'get',
             'name': 'namespace',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/namespace.json',
+            'output': 'v1/namespace.json#',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental',
-        },
-        "overview": {
-            'args': [],
-            'method': 'get',
-            'name': 'overview',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json',
-            'route': '/overview',
             'stability': 'experimental',
         },
         "ping": {

--- a/taskcluster/aio/purgecache.py
+++ b/taskcluster/aio/purgecache.py
@@ -22,8 +22,9 @@ class PurgeCache(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://purge-cache.taskcluster.net/v1/"
     }
+    serviceName = 'purge-cache'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/purgecacheevents.py
+++ b/taskcluster/aio/purgecacheevents.py
@@ -22,8 +22,10 @@ class PurgeCacheEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-purge-cache/v1/"
+        "exchangePrefix": "exchange/taskcluster-purge-cache/v1/",
     }
+    serviceName = 'purge-cache'
+    apiVersion = 'v1'
 
     def purgeCache(self, *args, **kwargs):
         """

--- a/taskcluster/aio/queue.py
+++ b/taskcluster/aio/queue.py
@@ -25,8 +25,9 @@ class Queue(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://queue.taskcluster.net/v1/"
     }
+    serviceName = 'queue'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/queueevents.py
+++ b/taskcluster/aio/queueevents.py
@@ -63,8 +63,10 @@ class QueueEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-queue/v1/"
+        "exchangePrefix": "exchange/taskcluster-queue/v1/",
     }
+    serviceName = 'queue'
+    apiVersion = 'v1'
 
     def taskDefined(self, *args, **kwargs):
         """

--- a/taskcluster/aio/secrets.py
+++ b/taskcluster/aio/secrets.py
@@ -23,8 +23,9 @@ class Secrets(AsyncBaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://secrets.taskcluster.net/v1/"
     }
+    serviceName = 'secrets'
+    apiVersion = 'v1'
 
     async def ping(self, *args, **kwargs):
         """

--- a/taskcluster/aio/treeherderevents.py
+++ b/taskcluster/aio/treeherderevents.py
@@ -23,8 +23,10 @@ class TreeherderEvents(AsyncBaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-treeherder/v1/"
+        "exchangePrefix": "exchange/taskcluster-treeherder/v1/",
     }
+    serviceName = 'treeherder'
+    apiVersion = 'v1'
 
     def jobs(self, *args, **kwargs):
         """
@@ -33,7 +35,7 @@ class TreeherderEvents(AsyncBaseClient):
         When a task run is scheduled or resolved, a message is posted to
         this exchange in a Treeherder consumable format.
 
-        This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
+        This exchange outputs: ``v1/pulse-job.json#``This exchange takes the following keys:
 
          * destination: destination (required)
 
@@ -59,7 +61,7 @@ class TreeherderEvents(AsyncBaseClient):
                     'name': 'reserved',
                 },
             ],
-            'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#',
+            'schema': 'v1/pulse-job.json#',
         }
         return self._makeTopicExchange(ref, *args, **kwargs)
 

--- a/taskcluster/auth.py
+++ b/taskcluster/auth.py
@@ -55,8 +55,9 @@ class Auth(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://auth.taskcluster.net/v1/"
     }
+    serviceName = 'auth'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/authevents.py
+++ b/taskcluster/authevents.py
@@ -24,8 +24,10 @@ class AuthEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-auth/v1/"
+        "exchangePrefix": "exchange/taskcluster-auth/v1/",
     }
+    serviceName = 'auth'
+    apiVersion = 'v1'
 
     def clientCreated(self, *args, **kwargs):
         """

--- a/taskcluster/awsprovisioner.py
+++ b/taskcluster/awsprovisioner.py
@@ -44,8 +44,9 @@ class AwsProvisioner(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://aws-provisioner.taskcluster.net/v1"
     }
+    serviceName = 'aws-provisioner'
+    apiVersion = 'v1'
 
     def listWorkerTypeSummaries(self, *args, **kwargs):
         """

--- a/taskcluster/awsprovisionerevents.py
+++ b/taskcluster/awsprovisionerevents.py
@@ -17,8 +17,9 @@ class AwsProvisionerEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/"
+        "exchangePrefix": "exchange/taskcluster-aws-provisioner/v1/",
     }
+    apiVersion = 'v1'
 
     def workerTypeCreated(self, *args, **kwargs):
         """

--- a/taskcluster/ec2manager.py
+++ b/taskcluster/ec2manager.py
@@ -17,8 +17,21 @@ class EC2Manager(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://ec2-manager.taskcluster.net/v1"
     }
+    serviceName = 'ec2-manager'
+    apiVersion = 'v1'
+
+    def ping(self, *args, **kwargs):
+        """
+        Ping Server
+
+        Respond without doing anything.
+        This endpoint is used to check that the service is up.
+
+        This method is ``stable``
+        """
+
+        return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     def listWorkerTypes(self, *args, **kwargs):
         """
@@ -26,7 +39,7 @@ class EC2Manager(BaseClient):
 
         This method is only for debugging the ec2-manager
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#``
+        This method gives output: ``v1/list-worker-types.json#``
 
         This method is ``experimental``
         """
@@ -39,7 +52,7 @@ class EC2Manager(BaseClient):
 
         Request an instance of a worker type
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#``
+        This method takes input: ``v1/run-instance-request.json#``
 
         This method is ``experimental``
         """
@@ -63,7 +76,7 @@ class EC2Manager(BaseClient):
 
         Return an object which has a generic state description. This only contains counts of instances
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#``
+        This method gives output: ``v1/worker-type-resources.json#``
 
         This method is ``experimental``
         """
@@ -76,7 +89,7 @@ class EC2Manager(BaseClient):
 
         Return a view of the health of a given worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/health.json#``
+        This method gives output: ``v1/health.json#``
 
         This method is ``experimental``
         """
@@ -89,7 +102,7 @@ class EC2Manager(BaseClient):
 
         Return a list of the most recent errors encountered by a worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/errors.json#``
+        This method gives output: ``v1/errors.json#``
 
         This method is ``experimental``
         """
@@ -102,7 +115,7 @@ class EC2Manager(BaseClient):
 
         Return state information for a given worker type
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/worker-type-state.json#``
+        This method gives output: ``v1/worker-type-state.json#``
 
         This method is ``experimental``
         """
@@ -115,7 +128,7 @@ class EC2Manager(BaseClient):
 
         Idempotently ensure that a keypair of a given name exists
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#``
+        This method takes input: ``v1/create-key-pair.json#``
 
         This method is ``experimental``
         """
@@ -150,7 +163,7 @@ class EC2Manager(BaseClient):
 
         Return a list of possible prices for EC2
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/prices.json#``
+        This method gives output: ``v1/prices.json#``
 
         This method is ``experimental``
         """
@@ -163,9 +176,9 @@ class EC2Manager(BaseClient):
 
         Return a list of possible prices for EC2
 
-        This method takes input: ``http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#``
+        This method takes input: ``v1/prices-request.json#``
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/prices.json#``
+        This method gives output: ``v1/prices.json#``
 
         This method is ``experimental``
         """
@@ -178,7 +191,7 @@ class EC2Manager(BaseClient):
 
         Give some basic stats on the health of our EC2 account
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/health.json#``
+        This method gives output: ``v1/health.json#``
 
         This method is ``experimental``
         """
@@ -191,7 +204,7 @@ class EC2Manager(BaseClient):
 
         Return a list of recent errors encountered
 
-        This method gives output: ``http://schemas.taskcluster.net/ec2-manager/v1/errors.json#``
+        This method gives output: ``v1/errors.json#``
 
         This method is ``experimental``
         """
@@ -289,29 +302,6 @@ class EC2Manager(BaseClient):
 
         return self._makeApiCall(self.funcinfo["purgeQueues"], *args, **kwargs)
 
-    def apiReference(self, *args, **kwargs):
-        """
-        API Reference
-
-        Generate an API reference for this service
-
-        This method is ``experimental``
-        """
-
-        return self._makeApiCall(self.funcinfo["apiReference"], *args, **kwargs)
-
-    def ping(self, *args, **kwargs):
-        """
-        Ping Server
-
-        Respond without doing anything.
-        This endpoint is used to check that the service is up.
-
-        This method is ``stable``
-        """
-
-        return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
-
     funcinfo = {
         "allState": {
             'args': [],
@@ -325,13 +315,6 @@ class EC2Manager(BaseClient):
             'method': 'get',
             'name': 'amiUsage',
             'route': '/internal/ami-usage',
-            'stability': 'experimental',
-        },
-        "apiReference": {
-            'args': [],
-            'method': 'get',
-            'name': 'apiReference',
-            'route': '/internal/api-reference',
             'stability': 'experimental',
         },
         "dbpoolStats": {
@@ -350,7 +333,7 @@ class EC2Manager(BaseClient):
         },
         "ensureKeyPair": {
             'args': ['name'],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#',
+            'input': 'v1/create-key-pair.json#',
             'method': 'get',
             'name': 'ensureKeyPair',
             'route': '/key-pairs/<name>',
@@ -360,7 +343,7 @@ class EC2Manager(BaseClient):
             'args': [],
             'method': 'get',
             'name': 'getHealth',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/health.json#',
+            'output': 'v1/health.json#',
             'route': '/health',
             'stability': 'experimental',
         },
@@ -368,7 +351,7 @@ class EC2Manager(BaseClient):
             'args': [],
             'method': 'get',
             'name': 'getPrices',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/prices.json#',
+            'output': 'v1/prices.json#',
             'route': '/prices',
             'stability': 'experimental',
         },
@@ -376,16 +359,16 @@ class EC2Manager(BaseClient):
             'args': [],
             'method': 'get',
             'name': 'getRecentErrors',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/errors.json#',
+            'output': 'v1/errors.json#',
             'route': '/errors',
             'stability': 'experimental',
         },
         "getSpecificPrices": {
             'args': [],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#',
+            'input': 'v1/prices-request.json#',
             'method': 'post',
             'name': 'getSpecificPrices',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/prices.json#',
+            'output': 'v1/prices.json#',
             'route': '/prices',
             'stability': 'experimental',
         },
@@ -393,7 +376,7 @@ class EC2Manager(BaseClient):
             'args': [],
             'method': 'get',
             'name': 'listWorkerTypes',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#',
+            'output': 'v1/list-worker-types.json#',
             'route': '/worker-types',
             'stability': 'experimental',
         },
@@ -427,7 +410,7 @@ class EC2Manager(BaseClient):
         },
         "runInstance": {
             'args': ['workerType'],
-            'input': 'http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#',
+            'input': 'v1/run-instance-request.json#',
             'method': 'put',
             'name': 'runInstance',
             'route': '/worker-types/<workerType>/instance',
@@ -458,7 +441,7 @@ class EC2Manager(BaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeErrors',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/errors.json#',
+            'output': 'v1/errors.json#',
             'route': '/worker-types/<workerType>/errors',
             'stability': 'experimental',
         },
@@ -466,7 +449,7 @@ class EC2Manager(BaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeHealth',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/health.json#',
+            'output': 'v1/health.json#',
             'route': '/worker-types/<workerType>/health',
             'stability': 'experimental',
         },
@@ -474,7 +457,7 @@ class EC2Manager(BaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeState',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/worker-type-state.json#',
+            'output': 'v1/worker-type-state.json#',
             'route': '/worker-types/<workerType>/state',
             'stability': 'experimental',
         },
@@ -482,7 +465,7 @@ class EC2Manager(BaseClient):
             'args': ['workerType'],
             'method': 'get',
             'name': 'workerTypeStats',
-            'output': 'http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#',
+            'output': 'v1/worker-type-resources.json#',
             'route': '/worker-types/<workerType>/stats',
             'stability': 'experimental',
         },

--- a/taskcluster/github.py
+++ b/taskcluster/github.py
@@ -25,8 +25,9 @@ class Github(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://github.taskcluster.net/v1/"
     }
+    serviceName = 'github'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/githubevents.py
+++ b/taskcluster/githubevents.py
@@ -22,8 +22,10 @@ class GithubEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-github/v1/"
+        "exchangePrefix": "exchange/taskcluster-github/v1/",
     }
+    serviceName = 'github'
+    apiVersion = 'v1'
 
     def pullRequest(self, *args, **kwargs):
         """

--- a/taskcluster/hooks.py
+++ b/taskcluster/hooks.py
@@ -30,13 +30,14 @@ class Hooks(BaseClient):
      * `['0 0 9,21 * * 1-5', '0 0 12 * * 0,6']` -- weekdays at 9:00 and 21:00 UTC, weekends at noon
 
     The task definition is used as a JSON-e template, with a context depending on how it is fired.  See
-    https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks
+    [/docs/reference/core/taskcluster-hooks/docs/firing-hooks](firing-hooks)
     for more information.
     """
 
     classOptions = {
-        "baseUrl": "https://hooks.taskcluster.net/v1/"
     }
+    serviceName = 'hooks'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/index.py
+++ b/taskcluster/index.py
@@ -108,8 +108,9 @@ class Index(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://index.taskcluster.net/v1/"
     }
+    serviceName = 'index'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/login.py
+++ b/taskcluster/login.py
@@ -18,8 +18,21 @@ class Login(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://login.taskcluster.net/v1"
     }
+    serviceName = 'login'
+    apiVersion = 'v1'
+
+    def ping(self, *args, **kwargs):
+        """
+        Ping Server
+
+        Respond without doing anything.
+        This endpoint is used to check that the service is up.
+
+        This method is ``stable``
+        """
+
+        return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
     def oidcCredentials(self, *args, **kwargs):
         """
@@ -37,7 +50,7 @@ class Login(BaseClient):
         ```
 
         The `access_token` is first verified against the named
-        :provider, then passed to the provider's API to retrieve a user
+        :provider, then passed to the provider's APIBuilder to retrieve a user
         profile. That profile is then used to generate Taskcluster credentials
         appropriate to the user. Note that the resulting credentials may or may
         not include a `certificate` property. Callers should be prepared for either
@@ -47,31 +60,19 @@ class Login(BaseClient):
         monitor this expiration and refresh the credentials if necessary, by calling
         this endpoint again, if they have expired.
 
-        This method gives output: ``http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json``
+        This method gives output: ``v1/oidc-credentials-response.json#``
 
         This method is ``experimental``
         """
 
         return self._makeApiCall(self.funcinfo["oidcCredentials"], *args, **kwargs)
 
-    def ping(self, *args, **kwargs):
-        """
-        Ping Server
-
-        Respond without doing anything.
-        This endpoint is used to check that the service is up.
-
-        This method is ``stable``
-        """
-
-        return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
-
     funcinfo = {
         "oidcCredentials": {
             'args': ['provider'],
             'method': 'get',
             'name': 'oidcCredentials',
-            'output': 'http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json',
+            'output': 'v1/oidc-credentials-response.json#',
             'route': '/oidc-credentials/<provider>',
             'stability': 'experimental',
         },

--- a/taskcluster/notify.py
+++ b/taskcluster/notify.py
@@ -19,8 +19,9 @@ class Notify(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://notify.taskcluster.net/v1/"
     }
+    serviceName = 'notify'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/pulse.py
+++ b/taskcluster/pulse.py
@@ -22,74 +22,9 @@ class Pulse(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://pulse.taskcluster.net/v1"
     }
-
-    def overview(self, *args, **kwargs):
-        """
-        Rabbit Overview
-
-        Get an overview of the Rabbit cluster.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json``
-
-        This method is ``experimental``
-        """
-
-        return self._makeApiCall(self.funcinfo["overview"], *args, **kwargs)
-
-    def listNamespaces(self, *args, **kwargs):
-        """
-        List Namespaces
-
-        List the namespaces managed by this service.
-
-        This will list up to 1000 namespaces. If more namespaces are present a
-        `continuationToken` will be returned, which can be given in the next
-        request. For the initial request, do not provide continuation.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json``
-
-        This method is ``experimental``
-        """
-
-        return self._makeApiCall(self.funcinfo["listNamespaces"], *args, **kwargs)
-
-    def namespace(self, *args, **kwargs):
-        """
-        Get a namespace
-
-        Get public information about a single namespace. This is the same information
-        as returned by `listNamespaces`.
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace.json``
-
-        This method is ``experimental``
-        """
-
-        return self._makeApiCall(self.funcinfo["namespace"], *args, **kwargs)
-
-    def claimNamespace(self, *args, **kwargs):
-        """
-        Claim a namespace
-
-        Claim a namespace, returning a username and password with access to that
-        namespace good for a short time.  Clients should call this endpoint again
-        at the re-claim time given in the response, as the password will be rotated
-        soon after that time.  The namespace will expire, and any associated queues
-        and exchanges will be deleted, at the given expiration time.
-
-        The `expires` and `contact` properties can be updated at any time in a reclaim
-        operation.
-
-        This method takes input: ``http://schemas.taskcluster.net/pulse/v1/namespace-request.json``
-
-        This method gives output: ``http://schemas.taskcluster.net/pulse/v1/namespace-response.json``
-
-        This method is ``experimental``
-        """
-
-        return self._makeApiCall(self.funcinfo["claimNamespace"], *args, **kwargs)
+    serviceName = 'pulse'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """
@@ -103,13 +38,70 @@ class Pulse(BaseClient):
 
         return self._makeApiCall(self.funcinfo["ping"], *args, **kwargs)
 
+    def listNamespaces(self, *args, **kwargs):
+        """
+        List Namespaces
+
+        List the namespaces managed by this service.
+
+        This will list up to 1000 namespaces. If more namespaces are present a
+        `continuationToken` will be returned, which can be given in the next
+        request. For the initial request, do not provide continuation token.
+
+        This method gives output: ``v1/list-namespaces-response.json#``
+
+        This method is ``experimental``
+        """
+
+        return self._makeApiCall(self.funcinfo["listNamespaces"], *args, **kwargs)
+
+    def namespace(self, *args, **kwargs):
+        """
+        Get a namespace
+
+        Get public information about a single namespace. This is the same information
+        as returned by `listNamespaces`.
+
+        This method gives output: ``v1/namespace.json#``
+
+        This method is ``experimental``
+        """
+
+        return self._makeApiCall(self.funcinfo["namespace"], *args, **kwargs)
+
+    def claimNamespace(self, *args, **kwargs):
+        """
+        Claim a namespace
+
+        Claim a namespace, returning a connection string with access to that namespace
+        good for use until the `reclaimAt` time in the response body. The connection
+        string can be used as many times as desired during this period, but must not
+        be used after `reclaimAt`.
+
+        Connections made with this connection string may persist beyond `reclaimAt`,
+        although it should not persist forever.  24 hours is a good maximum, and this
+        service will terminate connections after 72 hours (although this value is
+        configurable).
+
+        The specified `expires` time updates any existing expiration times.  Connections
+        for expired namespaces will be terminated.
+
+        This method takes input: ``v1/namespace-request.json#``
+
+        This method gives output: ``v1/namespace-response.json#``
+
+        This method is ``experimental``
+        """
+
+        return self._makeApiCall(self.funcinfo["claimNamespace"], *args, **kwargs)
+
     funcinfo = {
         "claimNamespace": {
             'args': ['namespace'],
-            'input': 'http://schemas.taskcluster.net/pulse/v1/namespace-request.json',
+            'input': 'v1/namespace-request.json#',
             'method': 'post',
             'name': 'claimNamespace',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/namespace-response.json',
+            'output': 'v1/namespace-response.json#',
             'route': '/namespace/<namespace>',
             'stability': 'experimental',
         },
@@ -117,8 +109,8 @@ class Pulse(BaseClient):
             'args': [],
             'method': 'get',
             'name': 'listNamespaces',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/list-namespaces-response.json',
-            'query': ['limit', 'continuation'],
+            'output': 'v1/list-namespaces-response.json#',
+            'query': ['limit', 'continuationToken'],
             'route': '/namespaces',
             'stability': 'experimental',
         },
@@ -126,16 +118,8 @@ class Pulse(BaseClient):
             'args': ['namespace'],
             'method': 'get',
             'name': 'namespace',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/namespace.json',
+            'output': 'v1/namespace.json#',
             'route': '/namespace/<namespace>',
-            'stability': 'experimental',
-        },
-        "overview": {
-            'args': [],
-            'method': 'get',
-            'name': 'overview',
-            'output': 'http://schemas.taskcluster.net/pulse/v1/rabbit-overview.json',
-            'route': '/overview',
             'stability': 'experimental',
         },
         "ping": {

--- a/taskcluster/purgecache.py
+++ b/taskcluster/purgecache.py
@@ -22,8 +22,9 @@ class PurgeCache(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://purge-cache.taskcluster.net/v1/"
     }
+    serviceName = 'purge-cache'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/purgecacheevents.py
+++ b/taskcluster/purgecacheevents.py
@@ -22,8 +22,10 @@ class PurgeCacheEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-purge-cache/v1/"
+        "exchangePrefix": "exchange/taskcluster-purge-cache/v1/",
     }
+    serviceName = 'purge-cache'
+    apiVersion = 'v1'
 
     def purgeCache(self, *args, **kwargs):
         """

--- a/taskcluster/queue.py
+++ b/taskcluster/queue.py
@@ -25,8 +25,9 @@ class Queue(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://queue.taskcluster.net/v1/"
     }
+    serviceName = 'queue'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/queueevents.py
+++ b/taskcluster/queueevents.py
@@ -63,8 +63,10 @@ class QueueEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-queue/v1/"
+        "exchangePrefix": "exchange/taskcluster-queue/v1/",
     }
+    serviceName = 'queue'
+    apiVersion = 'v1'
 
     def taskDefined(self, *args, **kwargs):
         """

--- a/taskcluster/secrets.py
+++ b/taskcluster/secrets.py
@@ -23,8 +23,9 @@ class Secrets(BaseClient):
     """
 
     classOptions = {
-        "baseUrl": "https://secrets.taskcluster.net/v1/"
     }
+    serviceName = 'secrets'
+    apiVersion = 'v1'
 
     def ping(self, *args, **kwargs):
         """

--- a/taskcluster/treeherderevents.py
+++ b/taskcluster/treeherderevents.py
@@ -23,8 +23,10 @@ class TreeherderEvents(BaseClient):
     """
 
     classOptions = {
-        "exchangePrefix": "exchange/taskcluster-treeherder/v1/"
+        "exchangePrefix": "exchange/taskcluster-treeherder/v1/",
     }
+    serviceName = 'treeherder'
+    apiVersion = 'v1'
 
     def jobs(self, *args, **kwargs):
         """
@@ -33,7 +35,7 @@ class TreeherderEvents(BaseClient):
         When a task run is scheduled or resolved, a message is posted to
         this exchange in a Treeherder consumable format.
 
-        This exchange outputs: ``http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#``This exchange takes the following keys:
+        This exchange outputs: ``v1/pulse-job.json#``This exchange takes the following keys:
 
          * destination: destination (required)
 
@@ -59,7 +61,7 @@ class TreeherderEvents(BaseClient):
                     'name': 'reserved',
                 },
             ],
-            'schema': 'http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#',
+            'schema': 'v1/pulse-job.json#',
         }
         return self._makeTopicExchange(ref, *args, **kwargs)
 

--- a/test/base/__init__.py
+++ b/test/base/__init__.py
@@ -17,17 +17,19 @@ if os.environ.get('DEBUG_TASKCLUSTER_CLIENT'):
 
 class TCTest(unittest.TestCase):
     """ Let's have a common base class for all Taskcluster-client tests."""
-    pass
+    test_root_url = 'https://tc-tests.example.com'
+    # rootUrl of a real deployment (that needs no pre-configuration)
+    real_root_url = 'https://taskcluster.net'
 
 
 def createApiRef(**kwargs):
     default = {
         'version': 0,
-        'apiVersion': 1,
+        'apiVersion': 'v1',
         'title': 'API Title',
         'description': 'API Description',
-        'baseUrl': 'https://fake.taskcluster.net/v1',
-        'exchangePrefix': 'test/v1',
+        'serviceName': 'fake',
+        'exchangePrefix': 'exchange/taskcluster-fake/v1',
         'entries': []
     }
     default.update(kwargs)

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -21,6 +21,7 @@ class TestAuthenticationAsync(base.TCTest):
         async def x():
             async with subjectAsync.createSession(loop=loop) as session:
                 client = subjectAsync.Auth({
+                    'rootUrl': self.real_root_url,
                     'credentials': {
                         'clientId': 'tester',
                         'accessToken': 'no-secret',
@@ -49,13 +50,14 @@ class TestAuthenticationAsync(base.TCTest):
                     ['test:xyz'],
                 )
                 client = subjectAsync.Auth({
+                    'rootUrl': self.real_root_url,
                     'credentials': tempCred,
                 }, session=session)
 
-                result = client.testAuthenticate({
+                result = await client.testAuthenticate({
                     'clientScopes': ['test:*'],
                     'requiredScopes': ['test:xyz'],
                 })
                 self.assertEqual(result, {'scopes': ['test:xyz'], 'clientId': 'tester'})
 
-        loop.run_until_complete
+        loop.run_until_complete(x())


### PR DESCRIPTION
This removes the concept of a baseUrl, requiring a rootUrl instead.  The
serviceName and apiVersion are intuited from the references if not
supplied directly, using logic based on that in the JS
taskcluster-client.

This is a breaking change, so warrants a major version bump.

There was some discussion of retaining the ability to use baseUrls for purposes of injecting services into other clusters (@petemoore's example with purge-caches).  I think we can still support this, but let's not call it baseUrl.  I want to make a clean break with baseUrls, and raising exceptions when they are provided is a robust way to do that.  Also, I think the names "baseUrl" and "rootUrl" are too easy to confuse. 

So, let's call it something more specific to the purpose, like `overrideServiceUrlPrefix`, and implement it across the board in all of the clients (once the rootUrl work and new client generation support is done).