### PR TITLE
Unpin reqs in setup.py

### DIFF
--- a/devDep.py
+++ b/devDep.py
@@ -21,3 +21,4 @@ except:
     pass
 
 pipMain(['install', '--upgrade'] + setup.tests_require + setup.install_requires)
+pipMain(['freeze'])

--- a/setup.py
+++ b/setup.py
@@ -10,28 +10,28 @@ import sys
 VERSION = '7.0.0'
 
 tests_require = [
-    'nose==1.3.7',
-    'nose-exclude==0.5.0',
-    'httmock==1.2.6',
-    'rednose==1.2.1',
-    'mock==1.0.1',
-    'setuptools-lint==0.3',
-    'flake8==2.5.0',
-    'psutil==2.1.3',
-    'hypothesis==3.6.1',
-    'tox==2.3.2',
-    'coverage==4.1b2',
-    'python-dateutil==2.6.0',
+    'nose',
+    'nose-exclude',
+    'httmock',
+    'rednose',
+    'mock',
+    'setuptools-lint',
+    'flake8',
+    'psutil',
+    'hypothesis',
+    'tox',
+    'coverage',
+    'python-dateutil',
 ]
 
 # requests has a policy of not breaking apis between major versions
 # http://docs.python-requests.org/en/latest/community/release-process/
 install_requires = [
-    'requests>=2.4.3,<3',
-    'mohawk>=0.3.4,<2.0',
-    'slugid>=2,<3',
-    'taskcluster-urls>=10.1.0,<12',
-    'six>=1.10.0,<2',
+    'requests>=2.4.3',
+    'mohawk>=0.3.4',
+    'slugid>=2',
+    'taskcluster-urls>=10.1.0',
+    'six>=1.10.0',
 ]
 
 # from http://testrun.org/tox/latest/example/basic.html
@@ -59,14 +59,14 @@ class Tox(TestCommand):
 
 if sys.version_info.major == 2:
     tests_require.extend([
-        'subprocess32==3.2.6',
+        'subprocess32',
     ])
 elif sys.version_info[:2] < (3, 5):
     raise Exception('This library does not support Python 3 versions below 3.5')
 elif sys.version_info[:2] >= (3, 5):
     install_requires.extend([
-        'aiohttp>=2.0.0,<4',
-        'async_timeout>=2.0.0,<4',
+        'aiohttp>=2.0.0',
+        'async_timeout>=2.0.0',
     ])
 
 if __name__ == '__main__':
@@ -74,8 +74,8 @@ if __name__ == '__main__':
         name='taskcluster',
         version=VERSION,
         description='Python client for Taskcluster',
-        author='John Ford',
-        author_email='jhford@mozilla.com',
+        author='Mozilla Taskcluster and Release Engineering',
+        author_email='release+python@mozilla.com',
         url='https://github.com/taskcluster/taskcluster-client.py',
         packages=['taskcluster', 'taskcluster.aio'],
         install_requires=install_requires,
@@ -85,5 +85,6 @@ if __name__ == '__main__':
         zip_safe=False,
         classifiers=['Programming Language :: Python :: 2.7',
                      'Programming Language :: Python :: 3.5',
-                     'Programming Language :: Python :: 3.6'],
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7'],
     )

--- a/taskcluster/aio/asyncclient.py
+++ b/taskcluster/aio/asyncclient.py
@@ -183,7 +183,7 @@ class AsyncBaseClient(BaseClient):
                 data = {}
                 try:
                     data = await response.json()
-                except:
+                except Exception:
                     pass  # Ignore JSON errors in error messages
                 # Find error message
                 message = "Unknown Server Error"
@@ -311,6 +311,7 @@ def createApiClient(name, api):
         attributes[entry['name']] = f
 
     return type(utils.toStr(name), (BaseClient,), attributes)
+
 
 __all__ = [
     'createTemporaryCredentials',

--- a/taskcluster/client.py
+++ b/taskcluster/client.py
@@ -69,7 +69,7 @@ class BaseClient(object):
                 if value and not isinstance(value, six.binary_type):
                     try:
                         credentials[x] = credentials[x].encode('ascii')
-                    except:
+                    except Exception:
                         s = '%s (%s) must be unicode encodable' % (x, credentials[x])
                         raise exceptions.TaskclusterAuthFailure(s)
 
@@ -516,7 +516,7 @@ class BaseClient(object):
                 data = {}
                 try:
                     data = response.json()
-                except:
+                except Exception:
                     pass  # Ignore JSON errors in error messages
                 # Find error message
                 message = "Unknown Server Error"

--- a/taskcluster/utils.py
+++ b/taskcluster/utils.py
@@ -27,13 +27,13 @@ log = logging.getLogger(__name__)
 # Regular expression matching: X days Y hours Z minutes
 # todo: support hr, wk, yr
 r = re.compile(''.join([
-   '^(\s*(?P<years>\d+)\s*y(ears?)?)?',
-   '(\s*(?P<months>\d+)\s*mo(nths?)?)?',
-   '(\s*(?P<weeks>\d+)\s*w(eeks?)?)?',
-   '(\s*(?P<days>\d+)\s*d(ays?)?)?',
-   '(\s*(?P<hours>\d+)\s*h(ours?)?)?',
-   '(\s*(?P<minutes>\d+)\s*m(in(utes?)?)?)?\s*',
-   '(\s*(?P<seconds>\d+)\s*s(ec(onds?)?)?)?\s*$',
+   r'^(\s*(?P<years>\d+)\s*y(ears?)?)?',
+   r'(\s*(?P<months>\d+)\s*mo(nths?)?)?',
+   r'(\s*(?P<weeks>\d+)\s*w(eeks?)?)?',
+   r'(\s*(?P<days>\d+)\s*d(ays?)?)?',
+   r'(\s*(?P<hours>\d+)\s*h(ours?)?)?',
+   r'(\s*(?P<minutes>\d+)\s*m(in(utes?)?)?)?\s*',
+   r'(\s*(?P<seconds>\d+)\s*s(ec(onds?)?)?)?\s*$',
 ]))
 
 
@@ -266,7 +266,7 @@ def makeHttpRequest(method, url, payload, headers, retries=MAX_RETRIES, session=
         # Handle non 2xx status code and retry if possible
         try:
             response.raise_for_status()
-        except requests.exceptions.RequestException as rerr:
+        except requests.exceptions.RequestException:
             pass
         status = response.status_code
         if 500 <= status and status < 600 and retry < retries:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -236,7 +236,7 @@ class TestScopeMatch(TestCase):
         try:
             result = subject.scopeMatch(assumed, requiredScopeSets)
             self.assertEqual(result, expected)
-        except:
+        except Exception:
             if expected != 'exception':
                 raise
 


### PR DESCRIPTION
We currently have somewhat complex requirements in setup.py, to support py2-install, py3-install, py2-test, and py3-test. We could address this with a tool like pip-compile-multi, with `base.in`, `aio.in`, `test.in`, `test-aio.in` unpinned requirements files that get expanded with pinning and hashes for all upstream deps.

However, this is also complicated by the fact that we get different sets of hashes and upstream deps based on host arch and python minor version. Also, as a library, we want to keep our pinning minimal: rather than specify the latest known good version of an upstream dep, we want to allow for a range of known good versions, in case other deps pin a different version.

We could support a large matrix of dependency tests: the first expected-good version, the latest expected-good version, and the latest unknown-status version of each dependency, across python minor versions. This would be thorough, but potentially time consuming to set up.

I'm currently leaning towards unpinning, and running [cron?] tests regularly against the latest version of dependencies. If these automated tests find errors, we can pin the dep to `<first.bad.version` until we fix. This PR is potentially the first step.

I believe this would resolve both #87 and #128.