### PR TITLE
Export createTemporaryCredentials (closes #123)

### DIFF
--- a/taskcluster/__init__.py
+++ b/taskcluster/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 from .client import createSession  # NOQA
+from .client import createTemporaryCredentials  # NOQA
 from taskcluster.utils import *  # NOQA
 from taskcluster.exceptions import *  # NOQA
 from taskcluster._client_importer import *  # NOQA


### PR DESCRIPTION
(Note that createTemporaryCredentials is exported just about everywhere -- `taskcluster`, `taskcluster.client`, `taskcluster.aio.client`, and on each of the per-service modules.  I guess that doesn't hurt..